### PR TITLE
Feature/improvements

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -4,7 +4,8 @@
       "Bash(swift build)",
       "Bash(swift test:*)",
       "Bash(find:*)",
-      "Bash(ls:*)"
+      "Bash(ls:*)",
+      "Bash(swift build *)"
     ],
     "deny": [],
     "ask": []

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ DerivedData/
 .swiftpm/configuration/registries.json
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
+REVIEW_FINDINGS.*

--- a/LogRExample/LogRExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/LogRExample/LogRExample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
-        "revision" : "fd16d76fd8b9a976d88bfb6cacc05ca8d19c91b6",
-        "version" : "1.1.0"
+        "revision" : "dcccb979a2183b8df3334237e3dc1ae2b4116a86",
+        "version" : "1.2.0"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/GRDB.swift",
       "state" : {
-        "revision" : "18497b68fdbb3a09528d260a0a0e1e7e61c8c53d",
-        "version" : "7.8.0"
+        "revision" : "36e30a6f1ef10e4194f6af0cff90888526f0c115",
+        "version" : "7.10.0"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/sqlite-data",
       "state" : {
-        "revision" : "b66b894b9a5710f1072c8eb6448a7edfc2d743d9",
-        "version" : "1.3.0"
+        "revision" : "da3a94ed49c7a30d82853de551c07a93196e8cab",
+        "version" : "1.6.1"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "8d9834a6189db730f6264db7556a7ffb751e99ee",
-        "version" : "1.4.0"
+        "revision" : "fea17c02d767f46b23070fdfdacc28a03a39232a",
+        "version" : "1.5.1"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
-        "version" : "1.3.3"
+        "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
+        "version" : "1.5.0"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "a10f9feeb214bc72b5337b6ef6d5a029360db4cc",
-        "version" : "1.10.0"
+        "revision" : "706feb7858a7f6c242879d137b8ee30926aa5b26",
+        "version" : "1.12.0"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-perception",
       "state" : {
-        "revision" : "4f47ebafed5f0b0172cf5c661454fa8e28fb2ac4",
-        "version" : "2.0.9"
+        "revision" : "25ac73741c3436605d61eceb5207e896973918e7",
+        "version" : "2.0.10"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-sharing",
       "state" : {
-        "revision" : "3bfc408cc2d0bee2287c174da6b1c76768377818",
-        "version" : "2.7.4"
+        "revision" : "bc27f8322bc30f6ce7d864d137dc77a6de8b57eb",
+        "version" : "2.8.0"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "a8b7c5e0ed33d8ab8887d1654d9b59f2cbad529b",
-        "version" : "1.18.7"
+        "revision" : "ad5e3190cc63dc288f28546f9c6827efc1e9d495",
+        "version" : "1.19.2"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-structured-queries",
       "state" : {
-        "revision" : "9c84335373bae5f5c9f7b5f0adf3ae10f2cab5b9",
-        "version" : "0.25.2"
+        "revision" : "8da8818fccd9959bd683934ddc62cf45bb65b3c8",
+        "version" : "0.31.1"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
-        "version" : "602.0.0"
+        "revision" : "9de99a78f099e59caf2b2beec65a4c45d54b2081",
+        "version" : "603.0.1"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "4c27acf5394b645b70d8ba19dc249c0472d5f618",
-        "version" : "1.7.0"
+        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
+        "version" : "1.9.0"
       }
     }
   ],

--- a/LogRExample/LogRExample/ContentView.swift
+++ b/LogRExample/LogRExample/ContentView.swift
@@ -7,6 +7,7 @@
 
 import Logr
 import SwiftUI
+import LogrUI
 
 struct ContentView: View {
     @Environment(\.logService) private var logger
@@ -14,10 +15,7 @@ struct ContentView: View {
     @State private var isGenerating = false
     @State private var generationProgress = ""
     @State private var showClearConfirmation = false
-
-    private var logCount: Int {
-        logger.recentLogs.count
-    }
+    @State private var stats: LogStatistics = .empty
 
     var body: some View {
         ScrollView {
@@ -44,6 +42,10 @@ struct ContentView: View {
         .onAppear {
             logger.info("ContentView appeared - Home tab loaded", category: .ui)
         }
+        .task(id: logger.recentLogs.count) {
+            // Statistics are computed off the main actor; refresh when the cache size changes.
+            stats = await logger.logStatistics()
+        }
     }
 
     // MARK: - Header
@@ -67,35 +69,32 @@ struct ContentView: View {
     // MARK: - Stats
 
     private var statsSection: some View {
+        // `stats` is computed off the main actor in `.task` and refreshed on cache-size change.
         VStack(spacing: 16) {
             HStack(spacing: 12) {
                 StatCard(title: "Total Logs",
-                         value: "\(logCount)",
+                         value: "\(stats.totalCount)",
                          icon: "doc.text.fill",
                          color: .blue)
 
                 StatCard(title: "In Memory",
-                         value: "\(logger.recentLogs.count)",
+                         value: "\(stats.totalCount)",
                          icon: "memorychip.fill",
                          color: .green)
             }
 
             HStack(spacing: 12) {
                 StatCard(title: "Errors",
-                         value: "\(countLogs(level: .error))",
+                         value: "\(stats.countByLevel[.error] ?? 0)",
                          icon: "exclamationmark.circle.fill",
                          color: .orange)
 
                 StatCard(title: "Faults",
-                         value: "\(countLogs(level: .fault))",
+                         value: "\(stats.countByLevel[.fault] ?? 0)",
                          icon: "xmark.octagon.fill",
                          color: .red)
             }
         }
-    }
-
-    private func countLogs(level: LogLevel) -> Int {
-        logger.recentLogs.count(where: { $0.level == level })
     }
 
     // MARK: - Quick Actions

--- a/LogRExample/LogRExample/ContentView.swift
+++ b/LogRExample/LogRExample/ContentView.swift
@@ -219,7 +219,6 @@ struct ContentView: View {
         }
 
         generationProgress = "Complete!"
-        try? await Task.sleep(for: .seconds(1.5))
 
         withAnimation {
             generationProgress = ""

--- a/LogRExample/LogRExample/LogDemoView.swift
+++ b/LogRExample/LogRExample/LogDemoView.swift
@@ -7,6 +7,7 @@
 
 import Logr
 import SwiftUI
+import LogrUI
 
 struct LogDemoView: View {
     @Environment(\.logService) private var logger
@@ -68,7 +69,7 @@ struct LogDemoView: View {
                     logAtLevel(level)
                 } label: {
                     HStack {
-                        Text(level.visualQueue)
+                        Text(level.visualCue)
                         Text(level.displayName)
                             .foregroundStyle(colorForLevel(level))
                         Spacer()

--- a/LogRExample/LogRExample/MockDataGenerator.swift
+++ b/LogRExample/LogRExample/MockDataGenerator.swift
@@ -20,7 +20,7 @@ private func logMessage(logger: LogRService, level: LogLevel, message: String, c
     }
 }
 
-enum MockDataGenerator {
+actor MockDataGenerator {
     // MARK: - Configuration
 
     private static let networkEndpoints = [
@@ -88,18 +88,18 @@ enum MockDataGenerator {
                                           count: Int = 2_000,
                                           privacyIssues: Int = 25,
                                           errorPatterns: Int = 50) async {
-        logger.info("Starting mock data generation: \(count) logs", category: .debug)
+        await logger.info("Starting mock data generation: \(count) logs", category: .debug)
 
         await generateNormalOperationLogs(logger: logger, count: count - privacyIssues - errorPatterns)
         await generatePrivacyIssueLogs(logger: logger, count: privacyIssues)
         await generateErrorPatternLogs(logger: logger, count: errorPatterns)
         await generateAppLifecycleLogs(logger: logger)
 
-        logger.notice("Mock data generation completed", category: .debug)
+        await logger.notice("Mock data generation completed", category: .debug)
     }
 
     // MARK: - Normal Operation Logs
-
+@concurrent
     private static func generateNormalOperationLogs(logger: LogRService, count: Int) async {
         let levels: [(LogLevel, Int)] = [
             (.debug, 40),
@@ -110,13 +110,9 @@ enum MockDataGenerator {
         ]
 
         for i in 0..<count {
-            let level = weightedRandomLevel(levels)
+            let level =  weightedRandomLevel(levels)
             let (message, category) = generateNormalLogContent(index: i)
-            logMessage(logger: logger, level: level, message: message, category: category)
-
-            if i % 500 == 0, i > 0 {
-                try? await Task.sleep(for: .milliseconds(10))
-            }
+            await logMessage(logger: logger, level: level, message: message, category: category)
         }
     }
 
@@ -229,7 +225,7 @@ enum MockDataGenerator {
         for i in 0..<count {
             let (message, category) = generatePrivacyIssueContent(index: i)
             let level: LogLevel = [.debug, .info, .warning].randomElement()!
-            logMessage(logger: logger, level: level, message: message, category: category)
+            await logMessage(logger: logger, level: level, message: message, category: category)
         }
     }
 
@@ -270,14 +266,14 @@ enum MockDataGenerator {
             if i % 3 == 0 {
                 let (message, category) = recurringErrors.randomElement()!
                 let level: LogLevel = i % 6 == 0 ? .fault : .error
-                logMessage(logger: logger, level: level, message: message, category: category)
+                await logMessage(logger: logger, level: level, message: message, category: category)
             } else {
-                generateRandomError(logger: logger, index: i)
+                await generateRandomError(logger: logger, index: i)
             }
         }
     }
 
-    private static func generateRandomError(logger: LogRService, index: Int) {
+    private static func generateRandomError(logger: LogRService, index: Int) async {
         let errorMsg = errorMessages.randomElement()!
         let endpoint = networkEndpoints.randomElement()!
 
@@ -291,7 +287,7 @@ enum MockDataGenerator {
         ]
 
         let (msg, cat, level) = scenarios.randomElement()!
-        logMessage(logger: logger, level: level, message: msg, category: cat)
+        await logMessage(logger: logger, level: level, message: msg, category: cat)
     }
 
     // MARK: - App Lifecycle Logs
@@ -309,7 +305,7 @@ enum MockDataGenerator {
         ]
 
         for (message, level, category) in lifecycleEvents {
-            logMessage(logger: logger, level: level, message: message, category: category)
+            await logMessage(logger: logger, level: level, message: message, category: category)
         }
     }
 

--- a/LogRExample/LogRExample/SettingsView.swift
+++ b/LogRExample/LogRExample/SettingsView.swift
@@ -8,6 +8,7 @@
 import Logr
 import SwiftUI
 import UniformTypeIdentifiers
+import LogrUI
 
 struct SettingsView: View {
     @Environment(\.logService) private var logger
@@ -85,7 +86,7 @@ struct SettingsView: View {
                 DisclosureGroup("Enabled Levels (\(logr.configuration.enabledLevels.count))") {
                     ForEach(LogLevel.allCases) { level in
                         HStack {
-                            Text(level.visualQueue)
+                            Text(level.visualCue)
                             Text(level.displayName)
                             Spacer()
                             if logr.configuration.enabledLevels.contains(level) {
@@ -155,7 +156,7 @@ struct SettingsView: View {
             }
 
             Button {
-                exportLogs()
+                Task { await exportLogs() }
             } label: {
                 Label("Export Logs", systemImage: "square.and.arrow.up")
             }
@@ -187,12 +188,7 @@ struct SettingsView: View {
         }
     }
 
-    private func exportLogs() {
-        guard let data = logger.exportLogs(format: selectedExportFormat) else {
-            exportError = "Failed to export logs"
-            return
-        }
-
+    private func exportLogs() async {
         let fileExtension = switch selectedExportFormat {
         case .json: "json"
         case .csv: "csv"
@@ -203,6 +199,11 @@ struct SettingsView: View {
         let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
 
         do {
+            let data = try await logger.exportLogs(format: selectedExportFormat)
+            guard !data.isEmpty else {
+                exportError = "Failed to export logs"
+                return
+            }
             try data.write(to: tempURL)
             exportedFileURL = tempURL
             logger.info("Logs exported successfully: \(filename)", category: .fileSystem)

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "b99a1b20dde15630bd30e12125db522237ffc2da711c2d05c1ce5c2f654d39e6",
+  "originHash" : "3f2586cd0150f3094529d46e608c29f90b5a08dd25f23d7127500233b52f3c28",
   "pins" : [
     {
       "identity" : "combine-schedulers",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/combine-schedulers",
       "state" : {
-        "revision" : "fd16d76fd8b9a976d88bfb6cacc05ca8d19c91b6",
-        "version" : "1.1.0"
+        "revision" : "dcccb979a2183b8df3334237e3dc1ae2b4116a86",
+        "version" : "1.2.0"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/groue/GRDB.swift",
       "state" : {
-        "revision" : "18497b68fdbb3a09528d260a0a0e1e7e61c8c53d",
-        "version" : "7.8.0"
+        "revision" : "36e30a6f1ef10e4194f6af0cff90888526f0c115",
+        "version" : "7.10.0"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/sqlite-data",
       "state" : {
-        "revision" : "b66b894b9a5710f1072c8eb6448a7edfc2d743d9",
-        "version" : "1.3.0"
+        "revision" : "da3a94ed49c7a30d82853de551c07a93196e8cab",
+        "version" : "1.6.1"
       }
     },
     {
@@ -49,10 +49,10 @@
     {
       "identity" : "swift-collections",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-collections",
+      "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
-        "version" : "1.3.0"
+        "revision" : "fea17c02d767f46b23070fdfdacc28a03a39232a",
+        "version" : "1.5.1"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
-        "version" : "1.3.3"
+        "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
+        "version" : "1.5.0"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-dependencies",
       "state" : {
-        "revision" : "a10f9feeb214bc72b5337b6ef6d5a029360db4cc",
-        "version" : "1.10.0"
+        "revision" : "706feb7858a7f6c242879d137b8ee30926aa5b26",
+        "version" : "1.12.0"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-perception",
       "state" : {
-        "revision" : "4f47ebafed5f0b0172cf5c661454fa8e28fb2ac4",
-        "version" : "2.0.9"
+        "revision" : "25ac73741c3436605d61eceb5207e896973918e7",
+        "version" : "2.0.10"
       }
     },
     {
@@ -105,8 +105,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-sharing",
       "state" : {
-        "revision" : "3bfc408cc2d0bee2287c174da6b1c76768377818",
-        "version" : "2.7.4"
+        "revision" : "bc27f8322bc30f6ce7d864d137dc77a6de8b57eb",
+        "version" : "2.8.0"
       }
     },
     {
@@ -114,8 +114,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
       "state" : {
-        "revision" : "a8b7c5e0ed33d8ab8887d1654d9b59f2cbad529b",
-        "version" : "1.18.7"
+        "revision" : "ad5e3190cc63dc288f28546f9c6827efc1e9d495",
+        "version" : "1.19.2"
       }
     },
     {
@@ -123,8 +123,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-structured-queries",
       "state" : {
-        "revision" : "9c84335373bae5f5c9f7b5f0adf3ae10f2cab5b9",
-        "version" : "0.25.2"
+        "revision" : "8da8818fccd9959bd683934ddc62cf45bb65b3c8",
+        "version" : "0.31.1"
       }
     },
     {
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
-        "version" : "602.0.0"
+        "revision" : "9de99a78f099e59caf2b2beec65a4c45d54b2081",
+        "version" : "603.0.1"
       }
     },
     {
@@ -141,8 +141,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/nicklockwood/SwiftFormat",
       "state" : {
-        "revision" : "e6fe3e445b95bca110da34e42c15d7c23ecef29a",
-        "version" : "0.58.6"
+        "revision" : "a5fa7a6a57abeb834df1b3fa43ea9133137d5ade",
+        "version" : "0.61.1"
       }
     },
     {
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "4c27acf5394b645b70d8ba19dc249c0472d5f618",
-        "version" : "1.7.0"
+        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
+        "version" : "1.9.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -21,9 +21,9 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/kishikawakatsumi/KeychainAccess", .upToNextMajor(from: "4.2.2")),
-        .package(url: "https://github.com/pointfreeco/sqlite-data", .upToNextMajor(from: "1.3.0")),
-        .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.58.6"),
-        .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.3.0"))
+        .package(url: "https://github.com/pointfreeco/sqlite-data", .upToNextMajor(from: "1.6.0")),
+           .package(url: "https://github.com/nicklockwood/SwiftFormat", from: "0.61.0"),
+           .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.5.1"))
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ import SwiftUI
 
 @main
 struct MyApp: App {
-    let logger = LogR()
+    let logger = try! LogR()
 
     var body: some Scene {
         WindowGroup {
@@ -119,10 +119,10 @@ import Logr
 @main
 struct MyApp: App {
     // Using SQLite storage (recommended for large volumes)
-    let logger = LogR(storage: SQLiteStorage())
+    let logger = try LogR(storage: SQLiteStorage())
 
     // Or using FileSystem storage
-    // let logger = LogR(storage: FileSystemStorage())
+    // let logger = try! LogR(storage: FileSystemStorage())
 
     var body: some Scene {
         WindowGroup {
@@ -236,7 +236,7 @@ logger.debug("Feature flag enabled", category: .custom("feature-flags"))
 
 ```swift
 // Uses sensible defaults
-let logger = LogR()
+let logger = try LogR()
 
 // Default configuration:
 // - maxLogEntries: 10,000
@@ -259,7 +259,7 @@ let config = LogrConfiguration(
     logVerbosity: .normal              // Normal verbosity (less detailed)
 )
 
-let logger = LogR(configuration: config)
+let logger = try LogR(configuration: config)
 ```
 
 #### Configuration Options
@@ -284,7 +284,7 @@ import SwiftUI
 import LogrUI
 
 struct ContentView: View {
-  @State private var logger = LogR(storage: SQLiteStorage())
+  @State private var logger = try! LogR(storage: SQLiteStorage())
   
     var body: some View {
         NavigationStack {
@@ -332,7 +332,7 @@ Automatically detect potential privacy issues in your logs:
 if #available(iOS 26.0, macOS 26.0, *) {
     // Create logger with AI analyzer
     let analyzer = AIAnalyzer()
-    let logger = LogR(logAnalyser: analyzer)
+    let logger = try LogR(logAnalyser: analyzer)
 
     // Scan for privacy issues
     Task {
@@ -395,7 +395,7 @@ LogR supports multiple storage backends with built-in encryption.
 
 ```swift
 // Logs only to OSLog, no persistent storage
-let logger = LogR()
+let logger = try LogR()
 ```
 
 ### FileSystem Storage
@@ -405,7 +405,7 @@ import Logr
 
 // Simple file-based storage
 let storage = FileSystemStorage()
-let logger = LogR(storage: storage)
+let logger = try LogR(storage: storage)
 ```
 
 Features:
@@ -421,7 +421,7 @@ import Logr
 
 // High-performance SQLite storage
 let storage = SQLiteStorage()
-let logger = LogR(storage: storage)
+let logger = try LogR(storage: storage)
 ```
 
 Features:
@@ -464,7 +464,7 @@ class CloudStorage: LogRPersistence {
     }
 }
 
-let logger = LogR(storage: CloudStorage())
+let logger = try LogR(storage: CloudStorage())
 ```
 
 ## Privacy & Security
@@ -480,7 +480,7 @@ All stored logs are automatically encrypted using:
 
 ```swift
 // Encryption is automatic with storage
-let logger = LogR(storage: SQLiteStorage())
+let logger = try LogR(storage: SQLiteStorage())
 
 // Logs are encrypted before storage
 logger.info("Sensitive operation completed")
@@ -607,7 +607,7 @@ let config = LogrConfiguration(logVerbosity: .verbose)
 let config = LogrConfiguration(logVerbosity: .normal)
 // Output: "Button tapped"
 
-let logger = LogR(configuration: config)
+let logger = try LogR(configuration: config)
 ```
 
 ### Dependency Injection
@@ -621,7 +621,7 @@ protocol AppDependencies {
 }
 
 class ProductionDependencies: AppDependencies {
-    lazy var logger: LogRService = LogR(
+    lazy var logger: LogRService = try! LogR(
         storage: SQLiteStorage(),
         configuration: LogrConfiguration(
             subsystem: "com.myapp.main"

--- a/Sources/Logr/AI/AIAnalyzer.swift
+++ b/Sources/Logr/AI/AIAnalyzer.swift
@@ -22,7 +22,7 @@ public struct AnalyzerConfiguration: Sendable {
 
     /// Maximum number of concurrent chunk requests when parallel processing is enabled.
     /// Foundation models have limited resources, so this prevents overwhelming the model.
-    /// A value of 2-3 is recommended for most devices.
+    /// Values are clamped to `1...8`; 2-3 is recommended for most devices (default: 3).
     public let maxConcurrentChunks: Int
 
     /// Pre-warm the model before first request.
@@ -30,11 +30,12 @@ public struct AnalyzerConfiguration: Sendable {
 
     public init(maxLogsPerRequest: Int = 20,
                 enableParallelProcessing: Bool = true,
-                maxConcurrentChunks: Int = 20,
+                maxConcurrentChunks: Int = 3,
                 prewarmModel: Bool = true) {
         self.maxLogsPerRequest = maxLogsPerRequest
         self.enableParallelProcessing = enableParallelProcessing
-        self.maxConcurrentChunks = max(1, maxConcurrentChunks)
+        // On-device models are resource constrained: keep concurrency in a safe range.
+        self.maxConcurrentChunks = max(1, min(maxConcurrentChunks, 8))
         self.prewarmModel = prewarmModel
     }
 
@@ -52,7 +53,7 @@ public actor AIAnalyzer: LogAIAnalyzer {
 
     public let configuration: AnalyzerConfiguration
     private let model: SystemLanguageModel
-    private var session: LanguageModelSession?
+    private var hasPrewarmed = false
 
     enum AnalysisType {
         case privacy
@@ -117,12 +118,6 @@ public actor AIAnalyzer: LogAIAnalyzer {
         return try await processInChunks(logs: logs, analysisType: .issues, onProgress: onProgress)
     }
 
-    // MARK: - Cleanup
-
-    deinit {
-        // Clean up session if needed
-        session = nil
-    }
 }
 
 // MARK: - Setup & Utils
@@ -164,9 +159,11 @@ private extension AIAnalyzer {
                                               - Be concise but comprehensive - no hallucination, no fluff
                                               """)
 
-        // Prewarm if configured
-        if configuration.prewarmModel {
+        // Prewarm once: the model load is shared across sessions, so there's no need to
+        // prewarm every per-chunk session.
+        if configuration.prewarmModel, !hasPrewarmed {
             newSession.prewarm()
+            hasPrewarmed = true
         }
 
         return newSession
@@ -347,7 +344,7 @@ private extension AIAnalyzer {
     func promptForIssuesAnalysing(logs: [LogEntry], logsText: String) -> String {
         // Count errors, warnings, faults for context
         let errors = logs.count(where: { $0.level == .error })
-        let warnings = logs.count(where: { $0.level == .notice })
+        let warnings = logs.count(where: { $0.level == .warning })
         let faults = logs.count(where: { $0.level == .fault })
 
         return """

--- a/Sources/Logr/LogR.swift
+++ b/Sources/Logr/LogR.swift
@@ -44,8 +44,6 @@ public final class LogR: LogRService, Sendable {
     private nonisolated(unsafe) var cleanupTimer: AnyCancellable?
     @ObservationIgnored
     private var cleanupTask: Task<Void, Never>?
-    @ObservationIgnored
-    private var encryptionTasks: [Task<Void, Never>] = []
 
     @ObservationIgnored
     private let writer: LogWriterActor?
@@ -70,7 +68,7 @@ public final class LogR: LogRService, Sendable {
         self.configuration = configuration
         self.cryptoService = cryptoService
         writer = if let storage {
-            LogWriterActor(storage: storage, configuration: configuration)
+            LogWriterActor(storage: storage, cryptoService: cryptoService, configuration: configuration)
         } else {
             nil
         }
@@ -101,17 +99,11 @@ public final class LogR: LogRService, Sendable {
     }
 
     deinit {
-        let pendingTasks = encryptionTasks
-        let writer = self.writer
         stopTimer()
-        if !pendingTasks.isEmpty || writer != nil {
-            Task {
-                for task in pendingTasks {
-                    await task.value
-                }
-                await writer?.flush()
-            }
-        }
+        // Finishing the writer's stream lets its consumer drain and persist any buffered
+        // entries, then releases it. This is best-effort; call `flush()` when you need a
+        // guarantee that pending entries are persisted before termination.
+        writer?.shutdown()
     }
 
     public func log(level: LogLevel,
@@ -148,19 +140,10 @@ public final class LogR: LogRService, Sendable {
         }
         recentLogs.prepend(entry)
 
-        let task = Task { [weak self, weak writer, cryptoService] in
-            do {
-                let encryptedLogData = try cryptoService.symmetricEncrypt(object: entry)
-                let encryptedLogEntry = EncryptedLogEntry(id: entry.id,
-                                                          timestamp: entry.timestamp,
-                                                          data: encryptedLogData)
-                await writer?.enqueue(encryptedLogEntry)
-            } catch {
-                self?.droppedLogCount += 1
-                self?.getLogger(for: .encryption).log(level: .error, "Failed to encrypt log entry: \(error)")
-            }
-        }
-        encryptionTasks.append(task)
+        // Hand the entry to the background writer. Encryption and batched persistence
+        // happen inside the actor's single consumer — no per-call Task is spawned and
+        // nothing accumulates on the main actor.
+        writer?.ingest(entry)
     }
 }
 
@@ -173,17 +156,7 @@ public extension LogR {
     }
 
     func flush() async {
-        let tasks = encryptionTasks
-        encryptionTasks.removeAll()
-        for task in tasks {
-            await task.value
-        }
-
-        guard let writer else {
-            return
-        }
-
-        await writer.flush()
+        await writer?.flush()
     }
 }
 
@@ -236,6 +209,35 @@ public extension LogR {
     }
 }
 
+// MARK: - Cleanup helpers
+
+extension LogR {
+    /// Removes entries older than `cutoff` from a newest-first deque.
+    ///
+    /// `recentLogs` is maintained newest-first, so expired entries always form a
+    /// contiguous tail. Trimming from the back is O(number-expired) and allocates
+    /// nothing when nothing has expired — unlike a full `filter`, which reallocated the
+    /// entire deque on every cleanup tick.
+    func trimExpiredEntries(_ entries: inout Deque<LogEntry>, olderThan cutoff: Date) {
+        while let oldest = entries.last, oldest.timestamp <= cutoff {
+            entries.removeLast()
+        }
+    }
+
+    /// Merges history loaded from storage into the in-memory cache.
+    ///
+    /// `historical` arrives oldest-first (as returned by `fetchEntries(limit:)`), while
+    /// `current` holds any logs captured during launch, newest-first. History is appended
+    /// newest-first after those live logs, then the cache is trimmed to `cap` (dropping the
+    /// oldest). This keeps `recentLogs` newest-first and never larger than `maxLogEntries`.
+    func mergeLoaded(_ historical: [LogEntry], into current: inout Deque<LogEntry>, cap: Int) {
+        current.append(contentsOf: historical.reversed())
+        while current.count > cap {
+            current.removeLast()
+        }
+    }
+}
+
 // MARK: - Setup & utils
 
 private extension LogR {
@@ -244,6 +246,13 @@ private extension LogR {
 
         setupCategoryLoggers()
         startCleanupTimer()
+        if let writer {
+            Task {
+                await writer.setOnDrop { [weak self] count in
+                    Task { @MainActor in self?.droppedLogCount += count }
+                }
+            }
+        }
         Task {
             await loadRecentLogs()
         }
@@ -258,7 +267,7 @@ private extension LogR {
 
     func startCleanupTimer() {
         cleanupTimer = Timer
-            .publish(every: 1.0, on: .main, in: .common)
+            .publish(every: configuration.cleanupInterval, on: .main, in: .common)
             .autoconnect()
             .sink { [weak self] _ in
                 self?.performCleanup()
@@ -278,7 +287,7 @@ private extension LogR {
 
     func performCleanup() {
         let cutoffDate = Date().addingTimeInterval(-configuration.maxLogAge)
-        recentLogs = recentLogs.filter { $0.timestamp > cutoffDate }
+        trimExpiredEntries(&recentLogs, olderThan: cutoffDate)
         guard cleanupTask == nil else { return }
         cleanupTask = Task {
             defer { cleanupTask = nil }
@@ -323,7 +332,10 @@ private extension LogR {
 private extension LogR {
     private func loadRecentLogs() async {
         do {
-            guard let encryptedLogs = try await storage?.fetchEntries() else { return }
+            // Load at most as many entries as the in-memory cache holds, rather than the
+            // entire persisted history.
+            guard let encryptedLogs = try await storage?.fetchEntries(limit: configuration.maxLogEntries)
+            else { return }
             var logs: [LogEntry] = []
             var decryptionFailures = 0
             for encrypted in encryptedLogs {
@@ -338,7 +350,7 @@ private extension LogR {
                 getLogger(for: .encryption)
                     .warning("Failed to decrypt \(decryptionFailures) of \(encryptedLogs.count) log entries")
             }
-            recentLogs.append(contentsOf: logs)
+           mergeLoaded(logs, into: &recentLogs, cap: configuration.maxLogEntries)
         } catch {
             getLogger(for: .system).error("Failed to load recent logs: \(error.localizedDescription)")
         }
@@ -347,44 +359,123 @@ private extension LogR {
 
 // MARK: - Background Writer Actor
 
+/// Background actor that encrypts and persists log entries.
+///
+/// Plaintext entries are handed in synchronously via ``ingest(_:)`` and delivered to a
+/// single consumer over an `AsyncStream`. The consumer encrypts each entry off the main
+/// actor, accumulates a batch, and writes it to storage with retry-on-failure. Using one
+/// ordered consumer means the caller never spawns a per-log task, nothing accumulates on
+/// the main actor, and entries are persisted in the order they were logged.
 actor LogWriterActor {
+    /// Events delivered to the single consumer.
+    private enum Event {
+        case entry(LogEntry)
+        case flush(CheckedContinuation<Void, Never>)
+    }
+
     private let storage: LogRPersistence
+    private let cryptoService: any LoggerCryptoServicing
     private let logger: Logger
-    private var pending: [EncryptedLogEntry] = []
-    private var writingTask: Task<Void, Never>?
     private let batchSize: Int
+    private let maxRetries: Int
+    private let continuation: AsyncStream<Event>.Continuation
+    private var onDrop: (@Sendable (Int) -> Void)?
 
-    init(storage: LogRPersistence, configuration: LogrConfiguration, batchSize: Int = 50) {
+    init(storage: LogRPersistence,
+         cryptoService: any LoggerCryptoServicing,
+         configuration: LogrConfiguration,
+         batchSize: Int = 50,
+         maxRetries: Int = 3) {
         self.storage = storage
+        self.cryptoService = cryptoService
         self.batchSize = batchSize
+        self.maxRetries = maxRetries
         logger = Logger(subsystem: configuration.subsystem, category: LogCategory.persistence.rawValue)
+        let (stream, continuation) = AsyncStream<Event>.makeStream()
+        self.continuation = continuation
+        Task { await self.consume(stream) }
     }
 
-    func enqueue(_ entry: EncryptedLogEntry) {
-        pending.append(entry)
-        guard writingTask == nil else { return }
-        writingTask = Task {
-            defer { writingTask = nil }
-            await drainPending()
+    /// Registers a callback invoked with the number of entries dropped (encryption
+    /// failures, or a batch abandoned after exhausting retries).
+    func setOnDrop(_ handler: @escaping @Sendable (Int) -> Void) {
+        onDrop = handler
+    }
+
+    /// Hands a plaintext entry to the writer. Synchronous and non-isolated so the main
+    /// actor's logging hot path neither awaits nor spawns a task.
+    nonisolated func ingest(_ entry: LogEntry) {
+        continuation.yield(.entry(entry))
+    }
+
+    /// Suspends until every entry enqueued before this call has been persisted.
+    nonisolated func flush() async {
+        await withCheckedContinuation { awaiter in
+            continuation.yield(.flush(awaiter))
         }
     }
 
-    func flush() async {
-        if let writingTask {
-            await writingTask.value
-        }
-        await drainPending()
+    /// Ends the stream so the consumer drains its buffer and exits. Best-effort.
+    nonisolated func shutdown() {
+        continuation.finish()
     }
 
-    private func drainPending() async {
-        while !pending.isEmpty {
-            let batch = Array(pending.prefix(batchSize))
-            pending.removeFirst(batch.count)
+    private func consume(_ stream: AsyncStream<Event>) async {
+        var batch: [EncryptedLogEntry] = []
+        batch.reserveCapacity(batchSize)
+        for await event in stream {
+            switch event {
+            case let .entry(entry):
+                if let encrypted = encrypt(entry) {
+                    batch.append(encrypted)
+                    if batch.count >= batchSize {
+                        await store(&batch)
+                    }
+                }
+            case let .flush(awaiter):
+                await store(&batch)
+                awaiter.resume()
+            }
+        }
+        // Stream finished (shutdown): persist whatever is still buffered.
+        await store(&batch)
+    }
+
+    private func encrypt(_ entry: LogEntry) -> EncryptedLogEntry? {
+        do {
+            let data = try cryptoService.symmetricEncrypt(object: entry)
+            return EncryptedLogEntry(id: entry.id, timestamp: entry.timestamp, data: data)
+        } catch {
+            logger.error("Failed to encrypt log entry: \(error.localizedDescription)")
+            onDrop?(1)
+            return nil
+        }
+    }
+
+    /// Stores `batch`, retrying with linear backoff. Entries are cleared only after a
+    /// successful write, so a transient failure never loses data. After `maxRetries`
+    /// failures the batch is dropped (and reported via `onDrop`) so the loop can't stall.
+    private func store(_ batch: inout [EncryptedLogEntry]) async {
+        guard !batch.isEmpty else { return }
+        let toStore = batch
+        var attempt = 0
+        while true {
             do {
-                try await storage.store(batch)
+                try await storage.store(toStore)
+                batch.removeAll(keepingCapacity: true)
+                return
             } catch {
-                logger.error("Failed to store log entry: \(error.localizedDescription)")
-                break
+                attempt += 1
+                if attempt >= maxRetries {
+                    logger.error("""
+                    Dropping \(toStore.count) log entries after \(attempt) failed store \
+                    attempts: \(error.localizedDescription)
+                    """)
+                    onDrop?(toStore.count)
+                    batch.removeAll(keepingCapacity: true)
+                    return
+                }
+                try? await Task.sleep(for: .milliseconds(50 * attempt))
             }
         }
     }

--- a/Sources/Logr/LogR.swift
+++ b/Sources/Logr/LogR.swift
@@ -7,8 +7,19 @@ import OSLog
 
 @Observable
 @MainActor
-public final class LogR: LogRService, Sendable {
-    public private(set) var recentLogs: Deque<LogEntry>
+public final class LogR: LogRService {
+    /// Backing store for ``recentLogs``. Mutated synchronously on every `log()` so reads are
+    /// always current, while the observation notification is fired separately and coalesced
+    /// (see ``scheduleObservation()``). A burst of logs therefore triggers at most one SwiftUI
+    /// invalidation per `coalesceWindowMillis` window, without ever hiding a logged entry from a
+    /// reader — including reads made through the `any LogRService` existential.
+    @ObservationIgnored private var _recentLogs: Deque<LogEntry>
+
+    public var recentLogs: Deque<LogEntry> {
+        access(keyPath: \.recentLogs)
+        return _recentLogs
+    }
+
     public let configuration: LogrConfiguration
 
     @available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 12.0, *)
@@ -48,22 +59,33 @@ public final class LogR: LogRService, Sendable {
     @ObservationIgnored
     private let writer: LogWriterActor?
 
-    private var _logIssueSummary: (any SendableMetatype)?
-    private var _privacyAnalysisResult: (any SendableMetatype)?
-    private var _analysisProgress: (any SendableMetatype)?
-    private var _analyser: (any SendableMetatype)?
+    /// The open observation-coalescing window, if any. While non-nil, logging keeps mutating
+    /// `_recentLogs` (so reads stay current) but defers the observation notification until the
+    /// window closes, so a burst produces a single SwiftUI invalidation. Cancelled on
+    /// `deinit`/`clearLogs`. `nonisolated(unsafe)` so the nonisolated `deinit` can cancel it; all
+    /// live accesses are on the main actor, and `deinit` only runs once no other reference
+    /// (including the task) is alive.
+    @ObservationIgnored
+    private nonisolated(unsafe) var observationWindow: Task<Void, Never>?
+
+    // Type-erased to `Any?` so these stored properties carry no `@available` requirement (a stored
+    // property cannot be annotated `@available`, and the analyzer types are iOS 26+). All access is
+    // through the main-actor-isolated, availability-gated computed properties below, which downcast
+    // back to the concrete type — so the erasure is safe and the metatype-only `SendableMetatype`
+    // (which every type trivially satisfies) bought nothing.
+    private var _logIssueSummary: Any?
+    private var _privacyAnalysisResult: Any?
+    private var _analysisProgress: Any?
+    private var _analyser: Any?
     @available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 12.0, *)
     private var analyser: LogAIAnalyzer? {
         _analyser as? LogAIAnalyzer
     }
 
-    @ObservationIgnored
-    private nonisolated(unsafe) var progressTask: Task<Void, Never>?
-
     public init(storage: LogRPersistence? = nil,
                 cryptoService: LoggerCryptoServicing,
                 configuration: LogrConfiguration = .default) {
-        recentLogs = Deque()
+        _recentLogs = Deque()
         self.storage = storage
         self.configuration = configuration
         self.cryptoService = cryptoService
@@ -100,6 +122,10 @@ public final class LogR: LogRService, Sendable {
 
     deinit {
         stopTimer()
+        // Cancel any open observation-coalescing window. No data is lost: every entry was already
+        // appended to `_recentLogs` synchronously and handed to the writer via `ingest`; only a
+        // pending (purely cosmetic) observation notification is dropped.
+        observationWindow?.cancel()
         // Finishing the writer's stream lets its consumer drain and persist any buffered
         // entries, then releases it. This is best-effort; call `flush()` when you need a
         // guarantee that pending entries are persisted before termination.
@@ -126,19 +152,25 @@ public final class LogR: LogRService, Sendable {
                              line: line,
                              metadata: metadata)
 
-        let categoryLogger = getLogger(for: category)
-
-        if configuration.logVerbosity == .verbose {
-            categoryLogger.log(level: level.osLogType,
-                               "[\(category.rawValue)][\(level.rawValue)] \(message) (\(file):\(function):\(line)")
-        } else {
-            categoryLogger.log(level: level.osLogType, "\(message)")
+        if configuration.mirrorToOSLog {
+            let categoryLogger = getLogger(for: category)
+            if configuration.logVerbosity == .verbose {
+                categoryLogger.log(level: level.osLogType,
+                                   "[\(category.rawValue)][\(level.rawValue)] \(message) (\(file):\(function):\(line)")
+            } else {
+                categoryLogger.log(level: level.osLogType, "\(message)")
+            }
         }
 
-        if recentLogs.count >= configuration.maxLogEntries {
-            _ = recentLogs.popLast()
+        // Append synchronously so every reader — including reads made through the
+        // `any LogRService` existential — sees the entry at once. The observation *notification*
+        // is fired on a coalesced schedule, so a burst of logs produces a handful of SwiftUI
+        // invalidations instead of one per entry, without ever hiding an entry from a reader.
+        _recentLogs.prepend(entry)
+        while _recentLogs.count > configuration.maxLogEntries {
+            _recentLogs.removeLast()
         }
-        recentLogs.prepend(entry)
+        scheduleObservation()
 
         // Hand the entry to the background writer. Encryption and batched persistence
         // happen inside the actor's single consumer — no per-call Task is spawned and
@@ -147,12 +179,54 @@ public final class LogR: LogRService, Sendable {
     }
 }
 
+// MARK: - Coalesced observation
+
+private extension LogR {
+    /// Notifies observers immediately if no window is open (so an isolated log invalidates at
+    /// once), then opens a window during which further logs mutate `_recentLogs` silently and a
+    /// single notification is fired when it closes. The result: at most one SwiftUI invalidation
+    /// per window, no matter how fast logs arrive. The data is never withheld — only the
+    /// notification is coalesced.
+    func scheduleObservation() {
+        guard observationWindow == nil else { return }
+        notifyObservers()
+        let windowMillis = max(0, configuration.coalesceWindowMillis)
+        observationWindow = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .milliseconds(windowMillis))
+            guard let self else { return }
+            // Close the window before notifying so a log arriving during the notification reopens one.
+            observationWindow = nil
+            notifyObservers()
+        }
+    }
+
+    /// Fires the observation for `recentLogs` without mutating it (the data was already updated
+    /// synchronously in `log()`), so SwiftUI re-reads the current value.
+    func notifyObservers() {
+        withMutation(keyPath: \.recentLogs) {}
+    }
+}
+
 // MARK: - Other util functions
 
 public extension LogR {
     func clearLogs() async throws {
-        try await storage?.clear()
-        recentLogs.removeAll()
+        // Wipe the in-memory cache synchronously, *before* the suspension below — no `log()` can
+        // interleave between the cancel and the removeAll. Cancel any open coalescing window first
+        // so a pending notification can't fire against the cleared cache.
+        observationWindow?.cancel()
+        observationWindow = nil
+        withMutation(keyPath: \.recentLogs) {
+            _recentLogs.removeAll()
+        }
+        // Clear persisted storage *through the writer* so the clear is ordered against in-flight
+        // writes: every entry ingested before this call (including any still buffered in the writer)
+        // is discarded, while an entry from a `log()` that races this `await` is ingested *after* the
+        // clear marker and therefore survives in both storage and `recentLogs` — they stay
+        // consistent. The writer exists exactly when storage does, so this fully covers wiping
+        // persisted entries. (If `storage.clear()` fails the error propagates; the in-memory cache is
+        // already cleared and storage reloads on next launch.)
+        try await writer?.clearPending()
     }
 
     func flush() async {
@@ -175,8 +249,8 @@ public extension LogR {
         let result: PrivacyAnalysisResult = if recentLogs.isEmpty {
             PrivacyAnalysisResult.empty
         } else {
-            try await analyser.scanForPrivacyIssues(logs: recentLogs.toArray) { [weak self] progress in
-                self?.updateProgress(progress: progress)
+            try await analyser.scanForPrivacyIssues(logs: recentLogs.toArray) { progress in
+                Task { @MainActor [weak self] in self?._analysisProgress = progress }
             }
         }
 
@@ -197,8 +271,8 @@ public extension LogR {
         let result: LogIssueSummary = if recentLogs.isEmpty {
             LogIssueSummary.empty
         } else {
-            try await analyser.summarizeIssues(logs: recentLogs.toArray) { [weak self] progress in
-                self?.updateProgress(progress: progress)
+            try await analyser.summarizeIssues(logs: recentLogs.toArray) { progress in
+                Task { @MainActor [weak self] in self?._analysisProgress = progress }
             }
         }
 
@@ -214,11 +288,12 @@ public extension LogR {
 extension LogR {
     /// Removes entries older than `cutoff` from a newest-first deque.
     ///
-    /// `recentLogs` is maintained newest-first, so expired entries always form a
+    /// `_recentLogs` is maintained newest-first, so expired entries always form a
     /// contiguous tail. Trimming from the back is O(number-expired) and allocates
     /// nothing when nothing has expired — unlike a full `filter`, which reallocated the
-    /// entire deque on every cleanup tick.
-    func trimExpiredEntries(_ entries: inout Deque<LogEntry>, olderThan cutoff: Date) {
+    /// entire deque on every cleanup tick. Pure (no instance state) so it is `static` and
+    /// directly unit-testable.
+    static func trimExpiredEntries(_ entries: inout Deque<LogEntry>, olderThan cutoff: Date) {
         while let oldest = entries.last, oldest.timestamp <= cutoff {
             entries.removeLast()
         }
@@ -229,8 +304,9 @@ extension LogR {
     /// `historical` arrives oldest-first (as returned by `fetchEntries(limit:)`), while
     /// `current` holds any logs captured during launch, newest-first. History is appended
     /// newest-first after those live logs, then the cache is trimmed to `cap` (dropping the
-    /// oldest). This keeps `recentLogs` newest-first and never larger than `maxLogEntries`.
-    func mergeLoaded(_ historical: [LogEntry], into current: inout Deque<LogEntry>, cap: Int) {
+    /// oldest). This keeps `_recentLogs` newest-first and never larger than `maxLogEntries`.
+    /// Pure (no instance state) so it is `static` and directly unit-testable.
+    static func mergeLoaded(_ historical: [LogEntry], into current: inout Deque<LogEntry>, cap: Int) {
         current.append(contentsOf: historical.reversed())
         while current.count > cap {
             current.removeLast()
@@ -242,7 +318,7 @@ extension LogR {
 
 private extension LogR {
     func setup() {
-        recentLogs.reserveCapacity(configuration.maxLogEntries)
+        _recentLogs.reserveCapacity(configuration.maxLogEntries)
 
         setupCategoryLoggers()
         startCleanupTimer()
@@ -287,7 +363,9 @@ private extension LogR {
 
     func performCleanup() {
         let cutoffDate = Date().addingTimeInterval(-configuration.maxLogAge)
-        trimExpiredEntries(&recentLogs, olderThan: cutoffDate)
+        withMutation(keyPath: \.recentLogs) {
+            Self.trimExpiredEntries(&_recentLogs, olderThan: cutoffDate)
+        }
         guard cleanupTask == nil else { return }
         cleanupTask = Task {
             defer { cleanupTask = nil }
@@ -317,14 +395,6 @@ private extension LogR {
         // Fall back to global enabled levels
         return configuration.enabledLevels.contains(level)
     }
-
-    @available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 12.0, *)
-    nonisolated func updateProgress(progress: AnalysisProgress) {
-        progressTask?.cancel()
-        progressTask = Task { @MainActor [weak self] in
-            self?._analysisProgress = progress
-        }
-    }
 }
 
 // MARK: - Local storage
@@ -350,7 +420,9 @@ private extension LogR {
                 getLogger(for: .encryption)
                     .warning("Failed to decrypt \(decryptionFailures) of \(encryptedLogs.count) log entries")
             }
-           mergeLoaded(logs, into: &recentLogs, cap: configuration.maxLogEntries)
+            withMutation(keyPath: \.recentLogs) {
+                Self.mergeLoaded(logs, into: &_recentLogs, cap: configuration.maxLogEntries)
+            }
         } catch {
             getLogger(for: .system).error("Failed to load recent logs: \(error.localizedDescription)")
         }
@@ -366,11 +438,32 @@ private extension LogR {
 /// actor, accumulates a batch, and writes it to storage with retry-on-failure. Using one
 /// ordered consumer means the caller never spawns a per-log task, nothing accumulates on
 /// the main actor, and entries are persisted in the order they were logged.
+///
+/// ## Backpressure
+///
+/// The number of entries buffered between ``ingest(_:)`` and the consumer is capped at
+/// `maxPendingWrites`. If storage falls behind under a sustained burst, the *newest* entries
+/// are shed (the oldest — likely the cause being diagnosed — are kept) and counted, rather
+/// than letting the buffer grow without bound. Shed counts are reported through the same
+/// `onDrop` callback as encryption/retry failures. The cap is applied only to entries:
+/// `flush`/`shutdown` control signals are never dropped, so `flush()` can never hang.
 actor LogWriterActor {
     /// Events delivered to the single consumer.
     private enum Event {
         case entry(LogEntry)
         case flush(CheckedContinuation<Void, Never>)
+        /// Discards any not-yet-persisted entries buffered ahead of this signal and clears storage.
+        /// Routed through the same stream as `entry`, so it is ordered *after* every entry ingested
+        /// before the `clear()` call (those are dropped) and *before* any ingested after it.
+        case clear(CheckedContinuation<Void, Error>)
+    }
+
+    /// Mutex-guarded backpressure state, shared between the nonisolated `ingest` producer and the
+    /// actor-isolated consumer. `inFlight` counts entries yielded but not yet consumed; `pendingDrops`
+    /// accumulates shed entries until the consumer can report them via `onDrop`.
+    private struct Backlog: Sendable {
+        var inFlight = 0
+        var pendingDrops = 0
     }
 
     private let storage: LogRPersistence
@@ -378,40 +471,73 @@ actor LogWriterActor {
     private let logger: Logger
     private let batchSize: Int
     private let maxRetries: Int
+    private let maxPendingWrites: Int
     private let continuation: AsyncStream<Event>.Continuation
+    /// `let` of a `Sendable` type, so the nonisolated producer can touch it without hopping actors.
+    private let backlog: any MutexProtected<Backlog> = SafeMutex.create(Backlog())
     private var onDrop: (@Sendable (Int) -> Void)?
 
     init(storage: LogRPersistence,
          cryptoService: any LoggerCryptoServicing,
          configuration: LogrConfiguration,
          batchSize: Int = 50,
-         maxRetries: Int = 3) {
+         maxRetries: Int = 3,
+         maxPendingWrites: Int = 100_000) {
         self.storage = storage
         self.cryptoService = cryptoService
         self.batchSize = batchSize
         self.maxRetries = maxRetries
+        self.maxPendingWrites = max(1, maxPendingWrites)
         logger = Logger(subsystem: configuration.subsystem, category: LogCategory.persistence.rawValue)
         let (stream, continuation) = AsyncStream<Event>.makeStream()
         self.continuation = continuation
         Task { await self.consume(stream) }
     }
 
-    /// Registers a callback invoked with the number of entries dropped (encryption
-    /// failures, or a batch abandoned after exhausting retries).
+    /// Registers a callback invoked with the number of entries dropped (encryption failures, a
+    /// batch abandoned after exhausting retries, or entries shed under backpressure).
     func setOnDrop(_ handler: @escaping @Sendable (Int) -> Void) {
         onDrop = handler
     }
 
     /// Hands a plaintext entry to the writer. Synchronous and non-isolated so the main
-    /// actor's logging hot path neither awaits nor spawns a task.
+    /// actor's logging hot path neither awaits nor spawns a task. Sheds the entry (and counts
+    /// it) when the pending buffer is already at `maxPendingWrites`, so memory stays bounded.
     nonisolated func ingest(_ entry: LogEntry) {
+        let cap = maxPendingWrites
+        let accepted = backlog.modify { state -> Bool in
+            guard state.inFlight < cap else {
+                state.pendingDrops += 1
+                return false
+            }
+            state.inFlight += 1
+            return true
+        }
+        guard accepted else { return }
         continuation.yield(.entry(entry))
     }
 
     /// Suspends until every entry enqueued before this call has been persisted.
     nonisolated func flush() async {
         await withCheckedContinuation { awaiter in
-            continuation.yield(.flush(awaiter))
+            // If the stream has already finished (post-`shutdown()`), `yield` returns `.terminated`
+            // and would silently drop the continuation — leaving this task suspended forever. Resume
+            // immediately in that case so `flush()` can never hang.
+            if case .terminated = continuation.yield(.flush(awaiter)) {
+                awaiter.resume()
+            }
+        }
+    }
+
+    /// Discards any buffered-but-unpersisted entries enqueued before this call and clears storage,
+    /// then suspends until that completes. Ordered through the stream so it never races with the
+    /// consumer's in-flight writes. Throws if the underlying `storage.clear()` fails.
+    nonisolated func clearPending() async throws {
+        try await withCheckedThrowingContinuation { (awaiter: CheckedContinuation<Void, Error>) in
+            // Stream already finished (post-`shutdown()`): nothing left to persist or clear.
+            if case .terminated = continuation.yield(.clear(awaiter)) {
+                awaiter.resume()
+            }
         }
     }
 
@@ -428,6 +554,7 @@ private extension LogWriterActor {
         for await event in stream {
             switch event {
             case let .entry(entry):
+                reportBackpressureDrops(consumedInFlight: 1)
                 if let encrypted = encrypt(entry) {
                     batch.append(encrypted)
                     if batch.count >= batchSize {
@@ -435,12 +562,40 @@ private extension LogWriterActor {
                     }
                 }
             case let .flush(awaiter):
+                reportBackpressureDrops(consumedInFlight: 0)
                 await store(&batch)
                 awaiter.resume()
+            case let .clear(awaiter):
+                reportBackpressureDrops(consumedInFlight: 0)
+                // Drop entries logged before the clear that haven't been persisted yet, then wipe
+                // storage. Entries delivered *after* this event survive (they were ingested after
+                // the caller asked to clear).
+                batch.removeAll(keepingCapacity: true)
+                do {
+                    try await storage.clear()
+                    awaiter.resume()
+                } catch {
+                    awaiter.resume(throwing: error)
+                }
             }
         }
         // Stream finished (shutdown): persist whatever is still buffered.
         await store(&batch)
+    }
+
+    /// Decrements the in-flight count for the entry just consumed and forwards any entries shed
+    /// under backpressure since the last report to `onDrop`, so callers can surface the loss.
+    func reportBackpressureDrops(consumedInFlight: Int) {
+        let dropped = backlog.modify { state -> Int in
+            state.inFlight -= consumedInFlight
+            let pending = state.pendingDrops
+            state.pendingDrops = 0
+            return pending
+        }
+        if dropped > 0 {
+            logger.error("Shed \(dropped) log entries under backpressure (storage fell behind)")
+            onDrop?(dropped)
+        }
     }
 
     func encrypt(_ entry: LogEntry) -> EncryptedLogEntry? {

--- a/Sources/Logr/LogR.swift
+++ b/Sources/Logr/LogR.swift
@@ -419,7 +419,9 @@ actor LogWriterActor {
     nonisolated func shutdown() {
         continuation.finish()
     }
+}
 
+private extension LogWriterActor {
     private func consume(_ stream: AsyncStream<Event>) async {
         var batch: [EncryptedLogEntry] = []
         batch.reserveCapacity(batchSize)
@@ -441,7 +443,7 @@ actor LogWriterActor {
         await store(&batch)
     }
 
-    private func encrypt(_ entry: LogEntry) -> EncryptedLogEntry? {
+    func encrypt(_ entry: LogEntry) -> EncryptedLogEntry? {
         do {
             let data = try cryptoService.symmetricEncrypt(object: entry)
             return EncryptedLogEntry(id: entry.id, timestamp: entry.timestamp, data: data)
@@ -455,7 +457,7 @@ actor LogWriterActor {
     /// Stores `batch`, retrying with linear backoff. Entries are cleared only after a
     /// successful write, so a transient failure never loses data. After `maxRetries`
     /// failures the batch is dropped (and reported via `onDrop`) so the loop can't stall.
-    private func store(_ batch: inout [EncryptedLogEntry]) async {
+    func store(_ batch: inout [EncryptedLogEntry]) async {
         guard !batch.isEmpty else { return }
         let toStore = batch
         var attempt = 0

--- a/Sources/Logr/Models/ExportFormat.swift
+++ b/Sources/Logr/Models/ExportFormat.swift
@@ -8,7 +8,7 @@
 import Foundation
 import UniformTypeIdentifiers
 
-public enum ExportFormat: CaseIterable, Identifiable {
+public enum ExportFormat: CaseIterable, Identifiable, Sendable {
     /// Standard JSON format.
     case json
     /// Comma-separated values format.

--- a/Sources/Logr/Models/LogLevel.swift
+++ b/Sources/Logr/Models/LogLevel.swift
@@ -57,7 +57,7 @@ import OSLog
 /// - ``osLogType``
 /// - ``displayName``
 /// - ``priority``
-/// - ``visualQueue``
+/// - ``visualCue``
 public enum LogLevel: String, CaseIterable, Sendable, Codable, Hashable, Identifiable, Equatable {
     /// Debug-level messages for development and active debugging.
     ///
@@ -151,7 +151,7 @@ public enum LogLevel: String, CaseIterable, Sendable, Codable, Hashable, Identif
     /// - info/notice: 🔵 (blue)
     /// - warning: 🟡 (yellow)
     /// - error/fault: 🔴 (red)
-    public var visualQueue: String {
+    public var visualCue: String {
         switch self {
         case .debug: "🟣"
         case .info, .notice: "🔵"

--- a/Sources/Logr/Models/LogrConfiguration.swift
+++ b/Sources/Logr/Models/LogrConfiguration.swift
@@ -53,7 +53,7 @@ public enum LogVerbosity: Sendable, Equatable, Codable {
 ///
 /// ```swift
 /// // Use default configuration
-/// let logger = LogR()
+/// let logger = try LogR()
 ///
 /// // Custom configuration for production
 /// let config = LogrConfiguration(
@@ -64,7 +64,7 @@ public enum LogVerbosity: Sendable, Equatable, Codable {
 ///     cleanupInterval: 30 * 60,  // 30 minutes
 ///     logVerbosity: .normal
 /// )
-/// let logger = LogR(configuration: config)
+/// let logger = try LogR(configuration: config)
 /// ```
 ///
 /// ## Topics
@@ -151,6 +151,28 @@ public struct LogrConfiguration: Sendable, Codable {
     /// Default: `.verbose`
     public let logVerbosity: LogVerbosity
 
+    /// Minimum interval, in milliseconds, between SwiftUI observation notifications for `recentLogs`.
+    ///
+    /// `recentLogs` is updated synchronously on every log, so every reader — including reads through
+    /// the `any LogRService` existential and `getLogs`/`exportLogs`/`logStatistics` — always sees the
+    /// latest entry immediately. This window throttles only how often *observers* (SwiftUI views) are
+    /// notified, coalescing a burst of logs into at most one view invalidation per window. It
+    /// decouples the redraw rate from the logging rate, keeping the UI responsive under high volume.
+    /// A larger value means fewer redraws but more latency before a burst is reflected on screen;
+    /// `0` notifies on every log.
+    ///
+    /// Default: 100 (≈10 notifications per second during a burst).
+    public let coalesceWindowMillis: Int
+
+    /// Whether each log is mirrored to Apple's unified logging system (OSLog) synchronously.
+    ///
+    /// When `true` (the default) every log is also written to OSLog so it appears in Console.app.
+    /// High-volume apps that rely on LogR's own persistent store can set this to `false` to avoid the
+    /// per-call OSLog cost during bursts.
+    ///
+    /// Default: `true`.
+    public let mirrorToOSLog: Bool
+
     /// Creates a new LogR configuration.
     ///
     /// All parameters have sensible defaults. Only specify the values you want to customize.
@@ -163,6 +185,8 @@ public struct LogrConfiguration: Sendable, Codable {
     ///   - subsystem: OSLog subsystem identifier. Default: Bundle identifier
     ///   - cleanupInterval: Cleanup frequency in seconds. Default: 1 hour
     ///   - logVerbosity: Output verbosity. Default: `.verbose`
+    ///   - coalesceWindowMillis: Min interval between `recentLogs` publications. Default: 100ms
+    ///   - mirrorToOSLog: Mirror each log to OSLog. Default: `true`
     public init(maxLogEntries: Int = LogrConfiguration.default.maxLogEntries,
                 maxLogAge: TimeInterval = LogrConfiguration.default.maxLogAge,
                 enabledLevels: Set<LogLevel> = LogrConfiguration.default.enabledLevels,
@@ -170,7 +194,9 @@ public struct LogrConfiguration: Sendable, Codable {
                     .categoryLevelOverrides,
                 subsystem: String = LogrConfiguration.default.subsystem,
                 cleanupInterval: TimeInterval = LogrConfiguration.default.cleanupInterval,
-                logVerbosity: LogVerbosity = LogrConfiguration.default.logVerbosity) {
+                logVerbosity: LogVerbosity = LogrConfiguration.default.logVerbosity,
+                coalesceWindowMillis: Int = LogrConfiguration.default.coalesceWindowMillis,
+                mirrorToOSLog: Bool = LogrConfiguration.default.mirrorToOSLog) {
         self.maxLogEntries = maxLogEntries
         self.maxLogAge = maxLogAge
         self.enabledLevels = enabledLevels
@@ -178,6 +204,41 @@ public struct LogrConfiguration: Sendable, Codable {
         self.subsystem = subsystem
         self.cleanupInterval = cleanupInterval
         self.logVerbosity = logVerbosity
+        self.coalesceWindowMillis = coalesceWindowMillis
+        self.mirrorToOSLog = mirrorToOSLog
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case maxLogEntries, maxLogAge, enabledLevels, categoryLevelOverrides
+        case subsystem, cleanupInterval, logVerbosity, coalesceWindowMillis, mirrorToOSLog
+    }
+
+    /// Forward-compatible decoding: any key absent from the payload falls back to its default
+    /// rather than throwing. This keeps configs encoded by an earlier version (which lacks fields
+    /// added later, e.g. `coalesceWindowMillis`/`mirrorToOSLog`) decodable, so adding a field stays
+    /// a non-breaking change. The synthesized `encode(to:)` continues to write every key.
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let defaults = LogrConfiguration.default
+        maxLogEntries = try container.decodeIfPresent(Int.self, forKey: .maxLogEntries)
+            ?? defaults.maxLogEntries
+        maxLogAge = try container.decodeIfPresent(TimeInterval.self, forKey: .maxLogAge)
+            ?? defaults.maxLogAge
+        enabledLevels = try container.decodeIfPresent(Set<LogLevel>.self, forKey: .enabledLevels)
+            ?? defaults.enabledLevels
+        categoryLevelOverrides = try container
+            .decodeIfPresent([LogCategory: LogLevel].self, forKey: .categoryLevelOverrides)
+            ?? defaults.categoryLevelOverrides
+        subsystem = try container.decodeIfPresent(String.self, forKey: .subsystem)
+            ?? defaults.subsystem
+        cleanupInterval = try container.decodeIfPresent(TimeInterval.self, forKey: .cleanupInterval)
+            ?? defaults.cleanupInterval
+        logVerbosity = try container.decodeIfPresent(LogVerbosity.self, forKey: .logVerbosity)
+            ?? defaults.logVerbosity
+        coalesceWindowMillis = try container.decodeIfPresent(Int.self, forKey: .coalesceWindowMillis)
+            ?? defaults.coalesceWindowMillis
+        mirrorToOSLog = try container.decodeIfPresent(Bool.self, forKey: .mirrorToOSLog)
+            ?? defaults.mirrorToOSLog
     }
 
     /// Default configuration with sensible values for most applications.
@@ -196,5 +257,7 @@ public struct LogrConfiguration: Sendable, Codable {
                                                     categoryLevelOverrides: nil,
                                                     subsystem: Bundle.main.bundleIdentifier ?? "com.logr.default",
                                                     cleanupInterval: 60 * 60,
-                                                    logVerbosity: .verbose)
+                                                    logVerbosity: .verbose,
+                                                    coalesceWindowMillis: 100,
+                                                    mirrorToOSLog: true)
 }

--- a/Sources/Logr/Protocols/LogAIAnalyzer.swift
+++ b/Sources/Logr/Protocols/LogAIAnalyzer.swift
@@ -35,7 +35,7 @@ import Foundation
 /// ```swift
 /// if #available(iOS 26.0, *) {
 ///     let analyzer = AIAnalyzer()
-///     let logger = LogR(logAnalyser: analyzer)
+///     let logger = try LogR(logAnalyser: analyzer)
 ///
 ///     // Check availability
 ///     if logger.canAnalyseLogs {
@@ -92,7 +92,7 @@ public protocol LogAIAnalyzer: Sendable {
     ///
     /// ```swift
     /// if #available(iOS 26.0, *) {
-    ///     let logger = LogR(logAnalyser: AIAnalyzer())
+    ///     let logger = try LogR(logAnalyser: AIAnalyzer())
     ///
     ///     if logger.canAnalyseLogs {
     ///         // AI features available

--- a/Sources/Logr/Protocols/LogRPersistence.swift
+++ b/Sources/Logr/Protocols/LogRPersistence.swift
@@ -107,6 +107,20 @@ public protocol LogRPersistence: Sendable {
     /// consider implementing pagination or limiting the returned entries.
     func fetchEntries() async throws -> [EncryptedLogEntry]
 
+    /// Fetches the most recent stored entries (up to `limit`), oldest first.
+    ///
+    /// Passing `nil` returns all entries (equivalent to ``fetchEntries()``). This is used
+    /// at logger startup to load only as many entries as the in-memory cache holds, rather
+    /// than decrypting the entire persisted history.
+    ///
+    /// A default implementation fetches everything and returns the latest `limit`.
+    /// Conformers backed by a query engine should override this to push the limit down to
+    /// storage (e.g. `ORDER BY timestamp DESC LIMIT ?`).
+    ///
+    /// - Parameter limit: The maximum number of (most recent) entries to return, or `nil`
+    ///   for all entries.
+    func fetchEntries(limit: Int?) async throws -> [EncryptedLogEntry]
+
     /// Deletes log entries older than the specified date.
     ///
     /// Part of the automatic cleanup process. Called periodically based on
@@ -144,4 +158,15 @@ public protocol LogRPersistence: Sendable {
     /// - Returns: The count of stored entries.
     /// - Throws: Storage-specific errors if the operation fails.
     func count() async throws -> Int
+}
+
+public extension LogRPersistence {
+    /// Default implementation: fetches all entries and returns the latest `limit`,
+    /// preserving the oldest-first order. Override for storage that can apply the limit
+    /// natively.
+    func fetchEntries(limit: Int?) async throws -> [EncryptedLogEntry] {
+        let all = try await fetchEntries()
+        guard let limit, limit < all.count else { return all }
+        return Array(all.suffix(limit))
+    }
 }

--- a/Sources/Logr/Protocols/LogRPersistence.swift
+++ b/Sources/Logr/Protocols/LogRPersistence.swift
@@ -161,6 +161,19 @@ public protocol LogRPersistence: Sendable {
 }
 
 public extension LogRPersistence {
+    /// Default implementation: stores each entry via the single-entry primitive.
+    ///
+    /// Keeps ``store(_:)-batch`` an additive, non-breaking requirement for existing conformers —
+    /// a custom backend that only implements the single-entry `store(_:)` still compiles.
+    /// Built-in backends (``SQLiteStorage``, ``FileSystemStorage``) override this with a single
+    /// batched write, which is far more efficient and should be preferred whenever the backend
+    /// supports it.
+    func store(_ entries: [EncryptedLogEntry]) async throws {
+        for entry in entries {
+            try await store(entry)
+        }
+    }
+
     /// Default implementation: fetches all entries and returns the latest `limit`,
     /// preserving the oldest-first order. Override for storage that can apply the limit
     /// natively.

--- a/Sources/Logr/Protocols/LogRService.swift
+++ b/Sources/Logr/Protocols/LogRService.swift
@@ -54,6 +54,7 @@ import DequeModule
 /// ### State Properties
 /// - ``recentLogs``
 /// - ``canAnalyseLogs``
+/// - ``droppedLogCount``
 /// - ``privacyAnalysisResult``
 /// - ``logIssueSummary``
 ///
@@ -89,6 +90,14 @@ public protocol LogRService: Observable, Sendable {
     /// This property returns `true` when running on iOS 26+ or macOS 26+ with an AI analyzer configured.
     /// When `false`, calling `scanForPrivacyIssues()` or `summarizeIssues()` will throw an error.
     var canAnalyseLogs: Bool { get }
+
+    /// The number of log entries that could not be persisted.
+    ///
+    /// Increments when an entry fails encryption, a storage write is abandoned after exhausting
+    /// retries, or an entry is shed under backpressure (storage falling behind a sustained burst).
+    /// `0` when no storage is configured or nothing has been dropped. Observe it to surface
+    /// silent log loss in diagnostics UI.
+    var droppedLogCount: Int { get }
 
     /// The most recent privacy analysis result (iOS 26+).
     ///
@@ -142,18 +151,25 @@ public protocol LogRService: Observable, Sendable {
 
     /// Exports all recent logs in the specified format.
     ///
+    /// Serialization runs off the main actor; an empty cache yields empty `Data` (not an error),
+    /// while a genuine encoding failure throws.
+    ///
     /// - Parameter format: The export format (`.json`, `.csv`, or `.txt`).
-    /// - Returns: The exported data, or `nil` if there are no logs to export.
+    /// - Returns: The exported data (empty when there are no logs).
+    /// - Throws: ``LogExportError`` if encoding fails.
     ///
     /// ## Example
     /// ```swift
-    /// if let jsonData = logger.exportLogs(format: .json) {
-    ///     try? jsonData.write(to: fileURL)
-    /// }
+    /// let jsonData = try await logger.exportLogs(format: .json)
+    /// try jsonData.write(to: fileURL)
     /// ```
-    func exportLogs(format: ExportFormat) -> Data?
+    func exportLogs(format: ExportFormat) async throws -> Data
 
-    func logStatistics() -> LogStatistics
+    /// Computes aggregate statistics over the recent-log cache.
+    ///
+    /// The computation (which touches every cached entry) runs off the main actor, so calling this
+    /// over a large cache does not stall the UI.
+    func logStatistics() async -> LogStatistics
 
     /// Clears all logs from both memory and persistent storage.
     ///
@@ -229,6 +245,11 @@ public protocol LogRService: Observable, Sendable {
 // MARK: - Utils implementations
 
 public extension LogRService {
+    /// Default: no drops reported. Concrete services that track persistence loss (e.g. ``LogR``)
+    /// override this; providing a default keeps `droppedLogCount` an additive, non-breaking
+    /// requirement for existing conformers.
+    var droppedLogCount: Int { 0 }
+
     func log(level: LogLevel,
              message: @autoclosure () -> String,
              category: LogCategory,
@@ -240,6 +261,8 @@ public extension LogRService {
             metadata: metadata)
     }
 
+    /// Returns logged entries, optionally filtered. `recentLogs` is always current (the concrete
+    /// service updates it synchronously), so no flush is required before reading.
     func getLogs(levels: Set<LogLevel>? = nil,
                  categories: Set<LogCategory>? = nil,
                  subsystems: Set<String>? = nil,
@@ -264,23 +287,47 @@ public extension LogRService {
         return Array(filteredLogs)
     }
 
-    func exportLogs(format: ExportFormat = .json) -> Data? {
-        guard !recentLogs.isEmpty else { return nil }
+    func exportLogs(format: ExportFormat = .json) async throws -> Data {
+        // Snapshot on the main actor, then serialize off it.
+        let snapshot = Array(recentLogs)
+        return try await LogExporter.serialize(snapshot, format: format)
+    }
 
-        // Get the base format data first
-        let baseData: Data?
+    func logStatistics() async -> LogStatistics {
+        // Snapshot on the main actor, then compute the per-entry aggregates off it.
+        let snapshot = Array(recentLogs)
+        return await LogStatisticsComputer.compute(from: snapshot)
+    }
+}
+
+// MARK: - Off-main serialization & statistics
+
+/// Errors thrown while exporting logs.
+public enum LogExportError: Error, Sendable {
+    /// The serialized text could not be encoded as UTF-8 data.
+    case encodingFailed
+}
+
+/// Serializes log entries to an export format off the main actor.
+///
+/// A dedicated, single-responsibility serializer: a new ``ExportFormat`` is added by extending the
+/// switch here, not by touching the logging facade.
+enum LogExporter {
+    @concurrent
+    static func serialize(_ logs: [LogEntry], format: ExportFormat) async throws -> Data {
+        guard !logs.isEmpty else { return Data() }
+
         switch format {
         case .json:
             let encoder = JSONEncoder()
             encoder.dateEncodingStrategy = .iso8601
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-            baseData = try? encoder.encode(recentLogs)
+            return try encoder.encode(logs)
 
         case .csv:
             let formatter = ISO8601DateFormatter()
-
             var rows: [String] = ["Timestamp,Level,Category,Subsystem,Message,File,Function,Line,Metadata"]
-            for log in recentLogs {
+            for log in logs {
                 let timestamp = formatter.string(from: log.timestamp)
                 let escapedMessage = log.message.replacingOccurrences(of: "\"", with: "\"\"")
                 let metadataStr = log.metadata?.map { "\($0.key)=\($0.value.stringValue)" }
@@ -288,36 +335,37 @@ public extension LogRService {
                 let escapedMetadata = metadataStr.replacingOccurrences(of: "\"", with: "\"\"")
                 rows.append("\"\(timestamp)\",\"\(log.level.rawValue)\",\"\(log.category)\",\"\(log.subsystem)\",\"\(escapedMessage)\",\"\(log.file)\",\"\(log.function)\",\(log.line),\"\(escapedMetadata)\"")
             }
-
-            baseData = rows.joined(separator: "\n").data(using: .utf8)
+            guard let data = rows.joined(separator: "\n").data(using: .utf8) else {
+                throw LogExportError.encodingFailed
+            }
+            return data
 
         case .txt:
             let formatter = DateFormatter()
             formatter.dateStyle = .medium
             formatter.timeStyle = .long
-
             var text = ""
-            for log in recentLogs {
-                var line = "\(log.level.visualQueue) [\(formatter.string(from: log.timestamp))] [\(log.level.displayName.uppercased())] [\(log.category)] [\(log.file)] \(log.message)"
+            for log in logs {
+                var line = "\(log.level.visualCue) [\(formatter.string(from: log.timestamp))] [\(log.level.displayName.uppercased())] [\(log.category)] [\(log.file)] \(log.message)"
                 if let metadata = log.metadata, !metadata.isEmpty {
                     let metadataStr = metadata.map { "\($0.key)=\($0.value.stringValue)" }.joined(separator: ", ")
                     line += " {\(metadataStr)}"
                 }
                 text += line + "\n"
             }
-
-            baseData = text.data(using: .utf8)
+            guard let data = text.data(using: .utf8) else {
+                throw LogExportError.encodingFailed
+            }
+            return data
         }
-
-        guard let data = baseData else { return nil }
-
-        return data
     }
+}
 
-    func logStatistics() -> LogStatistics {
-        guard !recentLogs.isEmpty else {
-            return .empty
-        }
+/// Computes aggregate ``LogStatistics`` off the main actor.
+enum LogStatisticsComputer {
+    @concurrent
+    static func compute(from logs: [LogEntry]) async -> LogStatistics {
+        guard !logs.isEmpty else { return .empty }
 
         let calendar = Calendar.current
         var countByLevel: [LogLevel: Int] = [:]
@@ -327,7 +375,7 @@ public extension LogRService {
         var minDate: Date?
         var maxDate: Date?
 
-        for log in recentLogs {
+        for log in logs {
             countByLevel[log.level, default: 0] += 1
             countByCategory[log.category, default: 0] += 1
 
@@ -349,7 +397,7 @@ public extension LogRService {
             nil
         }
 
-        return LogStatistics(totalCount: recentLogs.count,
+        return LogStatistics(totalCount: logs.count,
                              countByLevel: countByLevel,
                              countByCategory: countByCategory,
                              hourlyDistribution: hourlyDistribution,

--- a/Sources/Logr/Tools/LocalPersistency/FileSystemStorage.swift
+++ b/Sources/Logr/Tools/LocalPersistency/FileSystemStorage.swift
@@ -7,10 +7,27 @@
 
 import Foundation
 
+/// Append-only file storage for encrypted log entries using newline-delimited JSON
+/// (one entry per line).
+///
+/// Appending is O(batch): a `store` seeks to the end of the file and writes only the new
+/// lines, so write cost does not grow with the number of already-stored entries (the
+/// previous implementation re-read, re-sorted, and rewrote the entire file on every
+/// write). Full rewrites happen only during cleanup (`deleteEntries`) and `clear()`.
+///
+/// Entries are returned in insertion order, which — because the writer persists entries in
+/// the order they are logged — is chronological (oldest first), matching the
+/// ``LogRPersistence`` contract and ``SQLiteStorage``.
+///
+/// Files written by earlier versions (a single JSON array) are migrated to NDJSON the
+/// first time the file is opened.
 public actor FileSystemStorage: LogRPersistence {
     private let fileURL: URL
     private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
+
+    private static let newline = UInt8(ascii: "\n")
+    private static let openBracket = UInt8(ascii: "[")
 
     public init(fileName: String = "logr_entries.json") throws {
         guard let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
@@ -22,64 +39,88 @@ public actor FileSystemStorage: LogRPersistence {
         encoder.dateEncodingStrategy = .iso8601
         decoder.dateDecodingStrategy = .iso8601
 
-        try createFileIfNeededSync()
+        try prepareFile()
     }
 
     public func store(_ entry: EncryptedLogEntry) async throws {
-        var entries = try await fetchEntries()
-        entries.append(entry)
-
-        entries.sort { $0.timestamp > $1.timestamp }
-        try await saveEntries(entries)
+        try await store([entry])
     }
 
     public func store(_ newEntries: [EncryptedLogEntry]) async throws {
-        var entries = try await fetchEntries()
-        entries.append(contentsOf: newEntries)
-
-        entries.sort { $0.timestamp > $1.timestamp }
-        try await saveEntries(entries)
+        guard !newEntries.isEmpty else { return }
+        var payload = Data()
+        for entry in newEntries {
+            try payload.append(encoder.encode(entry))
+            payload.append(Self.newline)
+        }
+        let handle = try FileHandle(forWritingTo: fileURL)
+        defer { try? handle.close() }
+        try handle.seekToEnd()
+        try handle.write(contentsOf: payload)
     }
 
     public func fetchEntries() async throws -> [EncryptedLogEntry] {
-        let data = try Data(contentsOf: fileURL)
-        return try decoder.decode([EncryptedLogEntry].self, from: data)
+        Self.readEntries(at: fileURL, using: decoder)
     }
 
     public func deleteEntries(olderThan date: Date) async throws {
-        let entries = try await fetchEntries()
-        let filteredEntries = entries.filter { $0.timestamp > date }
-        try await saveEntries(filteredEntries)
+        let remaining = Self.readEntries(at: fileURL, using: decoder).filter { $0.timestamp > date }
+        try writeAll(remaining)
     }
 
     public func deleteEntries(keepingLatest count: Int) async throws {
-        let entries = try await fetchEntries()
-        let sortedEntries = entries.sorted { $0.timestamp > $1.timestamp }
-        let entriesToKeep = Array(sortedEntries.prefix(count))
-        try await saveEntries(entriesToKeep)
+        guard count >= 0 else { return }
+        let sorted = Self.readEntries(at: fileURL, using: decoder).sorted { $0.timestamp < $1.timestamp }
+        try writeAll(Array(sorted.suffix(count)))
     }
 
     public func clear() async throws {
-        try await saveEntries([])
+        try Data().write(to: fileURL, options: .atomic)
     }
 
     public func count() async throws -> Int {
-        try await fetchEntries().count
+        guard let data = try? Data(contentsOf: fileURL) else { return 0 }
+        // Each entry occupies exactly one newline-terminated line, so counting the
+        // newline bytes avoids decoding every entry.
+        return data.count(where: { $0 == Self.newline })
     }
 }
 
 private extension FileSystemStorage {
-    nonisolated func createFileIfNeededSync() throws {
-        guard !FileManager.default.fileExists(atPath: fileURL.path) else {
+    /// Creates the file if missing, or migrates a legacy single-JSON-array file to NDJSON.
+    nonisolated func prepareFile() throws {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            try Data().write(to: fileURL, options: .atomic)
             return
         }
-        let emptyEntries: [EncryptedLogEntry] = []
-        let data = try encoder.encode(emptyEntries)
-        try data.write(to: fileURL)
+        guard let data = try? Data(contentsOf: fileURL), data.first == Self.openBracket else {
+            return // already NDJSON (or empty)
+        }
+        // Legacy format detected: rewrite the JSON array as NDJSON.
+        let entries = (try? decoder.decode([EncryptedLogEntry].self, from: data)) ?? []
+        try writeAll(entries)
     }
 
-    func saveEntries(_ entries: [EncryptedLogEntry]) async throws {
-        let data = try encoder.encode(entries)
+    /// Rewrites the whole file as NDJSON. Used only by migration and cleanup.
+    nonisolated func writeAll(_ entries: [EncryptedLogEntry]) throws {
+        var data = Data()
+        for entry in entries {
+            try data.append(encoder.encode(entry))
+            data.append(Self.newline)
+        }
         try data.write(to: fileURL, options: .atomic)
+    }
+
+    static func readEntries(at url: URL, using decoder: JSONDecoder) -> [EncryptedLogEntry] {
+        guard let data = try? Data(contentsOf: url), !data.isEmpty else { return [] }
+        // Legacy format: a single JSON array (begins with '[').
+        if data.first == openBracket {
+            return (try? decoder.decode([EncryptedLogEntry].self, from: data)) ?? []
+        }
+        // NDJSON: one entry per line. Skip any unreadable line (e.g. a partial write
+        // after a crash) rather than discarding the whole file.
+        return data.split(separator: newline, omittingEmptySubsequences: true).compactMap {
+            try? decoder.decode(EncryptedLogEntry.self, from: Data($0))
+        }
     }
 }

--- a/Sources/Logr/Tools/LocalPersistency/FileSystemStorage.swift
+++ b/Sources/Logr/Tools/LocalPersistency/FileSystemStorage.swift
@@ -39,7 +39,7 @@ public actor FileSystemStorage: LogRPersistence {
         encoder.dateEncodingStrategy = .iso8601
         decoder.dateDecodingStrategy = .iso8601
 
-        try prepareFile()
+        try Self.prepareFile(at: fileURL, encoder: encoder, decoder: decoder)
     }
 
     public func store(_ entry: EncryptedLogEntry) async throws {
@@ -65,13 +65,13 @@ public actor FileSystemStorage: LogRPersistence {
 
     public func deleteEntries(olderThan date: Date) async throws {
         let remaining = Self.readEntries(at: fileURL, using: decoder).filter { $0.timestamp > date }
-        try writeAll(remaining)
+        try Self.writeAll(remaining, to: fileURL, using: encoder)
     }
 
     public func deleteEntries(keepingLatest count: Int) async throws {
         guard count >= 0 else { return }
         let sorted = Self.readEntries(at: fileURL, using: decoder).sorted { $0.timestamp < $1.timestamp }
-        try writeAll(Array(sorted.suffix(count)))
+        try Self.writeAll(Array(sorted.suffix(count)), to: fileURL, using: encoder)
     }
 
     public func clear() async throws {
@@ -88,27 +88,31 @@ public actor FileSystemStorage: LogRPersistence {
 
 private extension FileSystemStorage {
     /// Creates the file if missing, or migrates a legacy single-JSON-array file to NDJSON.
-    nonisolated func prepareFile() throws {
-        guard FileManager.default.fileExists(atPath: fileURL.path) else {
-            try Data().write(to: fileURL, options: .atomic)
+    ///
+    /// `static` (like ``readEntries(at:using:)``) so the throwing initializer can call it without
+    /// crossing actor isolation, and so a file-mutating helper never depends on — or appears to
+    /// escape — the actor's isolation.
+    static func prepareFile(at url: URL, encoder: JSONEncoder, decoder: JSONDecoder) throws {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            try Data().write(to: url, options: .atomic)
             return
         }
-        guard let data = try? Data(contentsOf: fileURL), data.first == Self.openBracket else {
+        guard let data = try? Data(contentsOf: url), data.first == openBracket else {
             return // already NDJSON (or empty)
         }
         // Legacy format detected: rewrite the JSON array as NDJSON.
         let entries = (try? decoder.decode([EncryptedLogEntry].self, from: data)) ?? []
-        try writeAll(entries)
+        try writeAll(entries, to: url, using: encoder)
     }
 
     /// Rewrites the whole file as NDJSON. Used only by migration and cleanup.
-    nonisolated func writeAll(_ entries: [EncryptedLogEntry]) throws {
+    static func writeAll(_ entries: [EncryptedLogEntry], to url: URL, using encoder: JSONEncoder) throws {
         var data = Data()
         for entry in entries {
             try data.append(encoder.encode(entry))
-            data.append(Self.newline)
+            data.append(newline)
         }
-        try data.write(to: fileURL, options: .atomic)
+        try data.write(to: url, options: .atomic)
     }
 
     static func readEntries(at url: URL, using decoder: JSONDecoder) -> [EncryptedLogEntry] {

--- a/Sources/Logr/Tools/LocalPersistency/SQLiteStorage.swift
+++ b/Sources/Logr/Tools/LocalPersistency/SQLiteStorage.swift
@@ -111,6 +111,19 @@ public extension SQLiteStorage {
         return results.map(\.toEncryptedLogEntry)
     }
 
+    func fetchEntries(limit: Int?) async throws -> [EncryptedLogEntry] {
+        guard let limit else { return try await fetchEntries() }
+        let results: [EncryptedLogEntryDAO] = try await database.read { db in
+            try EncryptedLogEntryDAO
+                .order { $0.timestamp.desc() }
+                .limit(limit)
+                .fetchAll(db)
+        }
+        // The query returns the latest entries newest-first; reverse to honor the
+        // oldest-first contract of `fetchEntries`.
+        return results.reversed().map(\.toEncryptedLogEntry)
+    }
+
     func deleteEntries(olderThan date: Date) async throws {
         try await database.write { db in
             try EncryptedLogEntryDAO

--- a/Sources/Logr/Tools/LoggerCryptoService.swift
+++ b/Sources/Logr/Tools/LoggerCryptoService.swift
@@ -177,11 +177,33 @@ public final class LoggerCryptoService: Sendable, LoggerCryptoServicing {
 
     let currentKeyVersion: any MutexProtected<KeyVersion> = SafeMutex.create(.default)
 
-    /// Private envelope to store encrypted data with key version
+    /// Private envelope to store encrypted data with key version.
+    ///
+    /// Decoding is tolerant of envelopes written before the `algorithm` field existed: those
+    /// were always ChaCha20-Poly1305, so an absent `algorithm` key decodes as `.chacha` rather
+    /// than failing. This keeps logs persisted by earlier versions readable after an upgrade.
     private struct CryptoEnvelope: Codable {
         let version: Int
         let data: Data
         let algorithm: CryptoAlgo
+
+        enum CodingKeys: String, CodingKey {
+            case version, data, algorithm
+        }
+
+        init(version: Int, data: Data, algorithm: CryptoAlgo) {
+            self.version = version
+            self.data = data
+            self.algorithm = algorithm
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            version = try container.decode(Int.self, forKey: .version)
+            data = try container.decode(Data.self, forKey: .data)
+            // Legacy envelopes predate the algorithm field and were always ChaCha20-Poly1305.
+            algorithm = try container.decodeIfPresent(CryptoAlgo.self, forKey: .algorithm) ?? .chacha
+        }
     }
 
     public enum CryptoAlgo: Sendable, Codable {
@@ -224,9 +246,7 @@ public final class LoggerCryptoService: Sendable, LoggerCryptoServicing {
         }
 
         let payload = try encoder.encode(object)
-        guard let encryptedPayload = try symmetricKey.encrypt(payload, algo: encryptionAlgo) else {
-            throw LoggerCryptoError.encryptionFailed
-        }
+        let encryptedPayload = try symmetricKey.encrypt(payload, algo: encryptionAlgo)
 
         let envelope = CryptoEnvelope(version: currentKeyVersion.value.value, data: encryptedPayload,
                                       algorithm: encryptionAlgo)
@@ -312,12 +332,18 @@ private extension Data {
 }
 
 private extension SymmetricKey {
-    func encrypt(_ clearData: Data, algo: LoggerCryptoService.CryptoAlgo) throws -> Data? {
+    func encrypt(_ clearData: Data, algo: LoggerCryptoService.CryptoAlgo) throws -> Data {
         switch algo {
         case .chacha:
-            try ChaChaPoly.seal(clearData, using: self).combined
+            // `ChaChaPoly.SealedBox.combined` is non-optional.
+            return try ChaChaPoly.seal(clearData, using: self).combined
         case .aes256gcm:
-            try AES.GCM.seal(clearData, using: self).combined
+            // `AES.GCM.SealedBox.combined` is `Data?` — non-nil only for a 96-bit nonce, which the
+            // nonce-less `seal` always generates. Surface the contract as a throw rather than `nil`.
+            guard let combined = try AES.GCM.seal(clearData, using: self).combined else {
+                throw LoggerCryptoError.encryptionFailed
+            }
+            return combined
         }
     }
 

--- a/Sources/LogrUI/AIAnalysisViews/IssueSummaryView.swift
+++ b/Sources/LogrUI/AIAnalysisViews/IssueSummaryView.swift
@@ -280,13 +280,9 @@ struct IssueRow: View {
             .cornerRadius(6)
     }
 
+    // Single source of truth — see `LogSeverity.tint` in Presentation.swift.
     private var severityColor: Color {
-        switch issue.severity {
-        case .critical: .red
-        case .high: .orange
-        case .medium: .yellow
-        default: .blue
-        }
+        issue.severity.tint
     }
 }
 

--- a/Sources/LogrUI/AIAnalysisViews/PrivacyWarningsView.swift
+++ b/Sources/LogrUI/AIAnalysisViews/PrivacyWarningsView.swift
@@ -205,21 +205,10 @@ private struct PrivacyWarningRow: View {
         .padding(.vertical, 8)
     }
 
+    // Single source of truth — see `LogSeverity.tint`/`symbolName` in Presentation.swift.
     private var severityIcon: some View {
-        switch warning.severity {
-        case .critical:
-            Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(.red)
-        case .high:
-            Image(systemName: "exclamationmark.circle.fill")
-                .foregroundStyle(.orange)
-        case .medium:
-            Image(systemName: "exclamationmark.circle")
-                .foregroundStyle(.yellow)
-        default:
-            Image(systemName: "info.circle")
-                .foregroundStyle(.blue)
-        }
+        Image(systemName: warning.severity.symbolName)
+            .foregroundStyle(warning.severity.tint)
     }
 }
 

--- a/Sources/LogrUI/LogViews/ExportSheet.swift
+++ b/Sources/LogrUI/LogViews/ExportSheet.swift
@@ -30,11 +30,10 @@ struct ExportSheet: View {
         }
     }
 
-    private func exportLogs(format: ExportFormat) {
+    private func exportLogs(format: ExportFormat) async {
         do {
-            guard let data = logr.exportLogs(format: format) else {
-                return
-            }
+            let data = try await logr.exportLogs(format: format)
+            guard !data.isEmpty else { return }
             let fileName = "logs_\(Date().timeIntervalSince1970).\(format.fileExtension)"
 
             // Save to app's Documents directory
@@ -88,8 +87,10 @@ private extension ExportSheet {
     var exportingActionsSection: some View {
         Section {
             Button("Export to Files App") {
-                exportLogs(format: selectedFormat)
-                dismiss()
+                Task {
+                    await exportLogs(format: selectedFormat)
+                    dismiss()
+                }
             }
             .frame(maxWidth: .infinity, alignment: .center)
         }

--- a/Sources/LogrUI/LogViews/LogEntryRow.swift
+++ b/Sources/LogrUI/LogViews/LogEntryRow.swift
@@ -31,11 +31,10 @@ struct LogEntryRow: View, @MainActor Equatable {
         .onChange(of: displayState) { _, newGlobalState in
             isExpanded = newGlobalState
         }
-//        .disclosureGroupStyle(CustomDisclosureGroupStyle(button: Text("ok")))
     }
 
     static func == (lhs: LogEntryRow, rhs: LogEntryRow) -> Bool {
-        lhs.entry == rhs.entry && lhs.isExpanded == rhs.isExpanded && lhs.displayState == rhs.displayState
+        lhs.entry == rhs.entry && lhs.displayState == rhs.displayState
     }
 }
 
@@ -120,27 +119,3 @@ struct LogLevelBadge: View {
         .white
     }
 }
-
-// struct CustomDisclosureGroupStyle<Label: View>: DisclosureGroupStyle {
-//    let button: Label
-//
-//    func makeBody(configuration: Configuration) -> some View {
-//        HStack {
-//            configuration.label
-//            Spacer()
-//            button
-//                .rotationEffect(.degrees(configuration.isExpanded ? 90 : 0))
-//        }
-//        .contentShape(Rectangle())
-//        .onTapGesture {
-//            withAnimation {
-//                configuration.isExpanded.toggle()
-//            }
-//        }
-//        if configuration.isExpanded {
-//            configuration.content
-//                .padding(.leading, 30)
-//                .disclosureGroupStyle(self)
-//        }
-//    }
-// }

--- a/Sources/LogrUI/LogViews/LogEntryRow.swift
+++ b/Sources/LogrUI/LogViews/LogEntryRow.swift
@@ -23,11 +23,13 @@ struct LogEntryRow: View, @MainActor Equatable {
                     DetailRow("Timestamp", entry.timestamp.formatted(.iso8601))
                 }
                 .font(.caption)
+                .frame(maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .init(horizontal: .leading, vertical: .top))
                 .foregroundStyle(.secondary)
             }
         } label: {
             mainRowContent
         }
+        .frame(maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .init(horizontal: .leading, vertical: .top))
         .onChange(of: displayState) { _, newGlobalState in
             isExpanded = newGlobalState
         }
@@ -40,34 +42,31 @@ struct LogEntryRow: View, @MainActor Equatable {
 
 private extension LogEntryRow {
     var mainRowContent: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack {
-                LogLevelBadge(level: entry.level)
-
-                VStack(alignment: .leading, spacing: 4) {
-                    HStack {
-                        Text(entry.category.displayName)
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-
-                        Spacer()
-
-                        Text(entry.timestamp, style: .time)
-                            .font(.caption2)
-                            .foregroundStyle(.tertiary)
-                    }
-                    Text(entry.message)
-                        .fontWeight(.semibold)
-                        .lineLimit(isExpanded ? nil : 3)
-                }
-
-                Spacer()
-            }
-            .contentShape(Rectangle())
-            .onTapGesture {
+        Button {
                 isExpanded.toggle()
+        } label: {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    LogLevelBadge(level: entry.level)
+                    Text(entry.category.displayName)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    Spacer()
+
+                    Text(entry.timestamp, style: .time)
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+                .fontWeight(.semibold)
+                Text(entry.message)
+                    .fontWeight(.semibold)
+                    .lineLimit(isExpanded ? nil : 3)
             }
+            .contentShape(.rect)
+            .frame(maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .init(horizontal: .leading, vertical: .top))
         }
+        .buttonStyle(.plain)
     }
 }
 
@@ -105,14 +104,7 @@ struct LogLevelBadge: View {
     }
 
     private var backgroundColor: Color {
-        switch level {
-        case .debug: .gray
-        case .info: .blue
-        case .notice: .green
-        case .error: .orange
-        case .fault: .red
-        case .warning: .yellow
-        }
+        level.tint
     }
 
     private var foregroundColor: Color {

--- a/Sources/LogrUI/LogViews/LogrUI.swift
+++ b/Sources/LogrUI/LogViews/LogrUI.swift
@@ -66,7 +66,8 @@ import UniformTypeIdentifiers
 ///
 /// @main
 /// struct MyApp: App {
-///     let logger = LogR(storage: SQLiteStorage())
+///     // Stored-property initializers can't use `try`; in real code prefer a throwing `init()`.
+///     let logger = try! LogR(storage: SQLiteStorage())
 ///
 ///     var body: some Scene {
 ///         WindowGroup {
@@ -104,6 +105,10 @@ public struct LogViewer: View {
     @State private var debouncedQuery = ""
     @State private var showError: Error?
     @State private var functionalityFilter = Set(LogViewer.Functionalities.allCases)
+    @State private var compactStatistics: LogStatistics = .empty
+    /// Share payloads precomputed off the main actor (export serialization is now `async`), so the
+    /// `ShareLink`s — which need their item at view-build time — read a ready value.
+    @State private var shareItems: [ExportFormat: ShareItem] = [:]
 
     enum SheetDestination: Identifiable {
         case filters
@@ -154,7 +159,8 @@ public struct LogViewer: View {
     ///
     /// @main
     /// struct MyApp: App {
-    ///     let logger = LogR()
+    ///     // Stored-property initializers can't use `try`; in real code prefer a throwing `init()`.
+    ///     let logger = try! LogR()
     ///
     ///     var body: some Scene {
     ///         WindowGroup {
@@ -221,30 +227,30 @@ public struct LogViewer: View {
         }
     }
 
-    private var filteredLogs: [LogEntry] {
-        filterData()
-    }
 }
 
 // MARK: - Main Content View
 
 private extension LogViewer {
     var mainContent: some View {
-        List {
+        // Filter once per body pass and reuse everywhere below. Reading it repeatedly would
+        // re-run the O(n) filter several times per update — costly on a large buffer.
+        let logs = filterData()
+        return List {
             // Statistics panel (collapsible)
-            if logFilterPreferences.showStatisticsPanel, !filteredLogs.isEmpty {
+            if logFilterPreferences.showStatisticsPanel, !logs.isEmpty {
                 Section {
-                    CompactLogStatisticsView(statistics: logr.logStatistics())
+                    CompactLogStatisticsView(statistics: compactStatistics)
                 }
             }
 
             // Log entries with optional grouping
             if logFilterPreferences.timeGrouping == .none {
-                ForEach(filteredLogs) { entry in
+                ForEach(logs) { entry in
                     logEntryRow(entry)
                 }
             } else {
-                ForEach(filteredLogs.grouped(by: logFilterPreferences.timeGrouping)) { group in
+                ForEach(logs.grouped(by: logFilterPreferences.timeGrouping)) { group in
                     Section {
                         ForEach(group.logs) { entry in
                             logEntryRow(entry)
@@ -262,6 +268,11 @@ private extension LogViewer {
             }
         }
         .searchable(text: $searchText, prompt: "Search logs...")
+        .task(id: logr.recentLogs.count) {
+            // Recompute derived data (stats + share payloads) off the main actor when the cache
+            // size changes, rather than synchronously on every body pass.
+            await refreshDerivedData()
+        }
         .task(id: searchText) {
             // Skip debounce for empty string (immediate clear)
             if searchText.isEmpty {
@@ -278,7 +289,7 @@ private extension LogViewer {
             toolbarContent
         }
         .overlay {
-            overlayContent
+            overlayContent(logs: logs)
         }
     }
 
@@ -296,8 +307,8 @@ private extension LogViewer {
 
 private extension LogViewer {
     @ViewBuilder
-    var overlayContent: some View {
-        if filteredLogs.isEmpty, !searchText.isEmpty {
+    func overlayContent(logs: [LogEntry]) -> some View {
+        if logs.isEmpty, !searchText.isEmpty {
             VStack(spacing: 20) {
                 Spacer()
                 Text("Couldn't find any logs corresponding to your search criteria \"\(searchText)\"")
@@ -313,7 +324,7 @@ private extension LogViewer {
             }
             .frame(maxHeight: .infinity)
             .padding(.horizontal)
-        } else if filteredLogs.isEmpty, debouncedQuery.isEmpty {
+        } else if logs.isEmpty, debouncedQuery.isEmpty {
             ContentUnavailableView {
                 Image(systemName: "text.page.badge.magnifyingglass")
                     .resizable()
@@ -428,7 +439,7 @@ private extension LogViewer {
             Menu("Export & Share") {
                 ForEach(ExportFormat.allCases) { format in
                     let fileName = format.formatName
-                    ShareLink(item: prepareShareItem(format: format, fileName: fileName),
+                    ShareLink(item: shareItems[format] ?? .empty,
                               preview: SharePreview("LogR Export")) {
                         Label("Share \(fileName)", systemImage: "square.and.arrow.up")
                     }
@@ -450,12 +461,21 @@ private extension LogViewer {
 // MARK: - Logic actions
 
 private extension LogViewer {
-    func prepareShareItem(format: ExportFormat, fileName: String) -> ShareItem {
-        guard let data = logr.exportLogs(format: format) else {
-            return .empty
-        }
+    /// Refreshes the off-main–computed derived data: the compact statistics and, when sharing is
+    /// enabled, the per-format share payloads. Serialization no longer runs on the main actor.
+    func refreshDerivedData() async {
+        compactStatistics = await logr.logStatistics()
 
-        return ShareItem(data: data, fileName: fileName, contentType: format.contentType)
+        guard functionalityFilter.contains(.sharing), !logr.recentLogs.isEmpty else {
+            shareItems = [:]
+            return
+        }
+        var items: [ExportFormat: ShareItem] = [:]
+        for format in ExportFormat.allCases {
+            guard let data = try? await logr.exportLogs(format: format), !data.isEmpty else { continue }
+            items[format] = ShareItem(data: data, fileName: format.formatName, contentType: format.contentType)
+        }
+        shareItems = items
     }
 
     func clearAllLogs() {

--- a/Sources/LogrUI/LogViews/LogrUI.swift
+++ b/Sources/LogrUI/LogViews/LogrUI.swift
@@ -282,7 +282,6 @@ private extension LogViewer {
         }
     }
 
-    @ViewBuilder
     private func logEntryRow(_ entry: LogEntry) -> some View {
         #if os(macOS)
         LogEntryRow(entry: entry, displayState: $logFilterPreferences.allExpanded)

--- a/Sources/LogrUI/Mock+Previews/MockLogR.swift
+++ b/Sources/LogrUI/Mock+Previews/MockLogR.swift
@@ -131,6 +131,8 @@ public final class MockLogR: LogRService, Sendable {
 
     public var canAnalyseLogs: Bool = true
 
+    public var droppedLogCount = 0
+
     public private(set) var recentLogs = Deque<LogEntry>()
     public private(set) var isCleanupRunning = false
 

--- a/Sources/LogrUI/Statistics/LogStatisticsView.swift
+++ b/Sources/LogrUI/Statistics/LogStatisticsView.swift
@@ -30,9 +30,7 @@ import SwiftUI
 public struct LogStatisticsView: View {
     @Environment(\.logService) private var logr
 
-    private var statistics: LogStatistics {
-        logr.logStatistics()
-    }
+    @State private var statistics: LogStatistics = .empty
 
     public init() {}
 
@@ -47,6 +45,12 @@ public struct LogStatisticsView: View {
             .padding()
         }
         .navigationTitle("Log Statistics")
+        // Recompute off the main actor when the number of cached logs changes, instead of on every
+        // body pass: the previous computed property re-ran the full aggregation (a Calendar op per
+        // entry, up to `maxLogEntries`) on each SwiftUI update.
+        .task(id: logr.recentLogs.count) {
+            statistics = await logr.logStatistics()
+        }
     }
 
     @ViewBuilder
@@ -99,7 +103,7 @@ public struct LogStatisticsView: View {
 
                 HStack {
                     Circle()
-                        .fill(colorForLevel(level))
+                        .fill(level.tint)
                         .frame(width: 12, height: 12)
 
                     Text(level.displayName.capitalized)
@@ -186,22 +190,6 @@ public struct LogStatisticsView: View {
         .cornerRadius(12)
     }
 
-    private func colorForLevel(_ level: LogLevel) -> Color {
-        switch level {
-        case .debug:
-            .gray
-        case .info:
-            .blue
-        case .notice:
-            .cyan
-        case .warning:
-            .orange
-        case .error:
-            .red
-        case .fault:
-            .purple
-        }
-    }
 }
 
 // MARK: - Stat Card
@@ -264,7 +252,7 @@ public struct CompactLogStatisticsView: View {
                             .foregroundStyle(.secondary)
                         Text("\(statistics.countByLevel[.error] ?? 0)")
                             .font(.headline.monospacedDigit())
-                            .foregroundStyle(.red)
+                            .foregroundStyle(LogLevel.error.tint)
                     }
                     Divider()
                     VStack {
@@ -273,7 +261,7 @@ public struct CompactLogStatisticsView: View {
                             .foregroundStyle(.secondary)
                         Text("\(statistics.countByLevel[.warning] ?? 0)")
                             .font(.headline.monospacedDigit())
-                            .foregroundStyle(.orange)
+                            .foregroundStyle(LogLevel.warning.tint)
                     }
                 }
                 .padding()
@@ -298,13 +286,15 @@ public struct CompactLogStatisticsView: View {
 
 #Preview("Log Statistics") {
     @Previewable @State var mock = MockLogR()
+    @Previewable @State var compactStats = LogStatistics.empty
     NavigationStack {
         List {
-            CompactLogStatisticsView(statistics: mock.logStatistics())
+            CompactLogStatisticsView(statistics: compactStats)
                 .padding()
             LogStatisticsView()
         }
         .listStyle(.plain)
     }
     .environment(\.logService, mock)
+    .task { compactStats = await mock.logStatistics() }
 }

--- a/Sources/LogrUI/Tools+Extensions/DisabledLogR.swift
+++ b/Sources/LogrUI/Tools+Extensions/DisabledLogR.swift
@@ -1,0 +1,64 @@
+//
+//  DisabledLogR.swift
+//  Logr
+//
+//  Created by martin on 02/06/2026.
+//
+
+import Collections
+import DequeModule
+import Foundation
+import Logr
+
+// MARK: - No-op Implementation
+
+/// A no-op ``LogRService`` used as the default value for the `logService`
+/// environment key when no real logger has been injected.
+///
+/// Every logging call is silently discarded, the log cache is always empty, and
+/// AI analysis reports as unavailable. This lets `LogrUI` views render a safe,
+/// empty state instead of forcing an optional environment value (and the side
+/// effects of constructing a real ``LogR`` as a default).
+///
+/// Inject a real service with ``SwiftUICore/View/logRService(_:)`` (or
+/// `.environment(\.logService, logger)`) to enable functionality.
+@Observable
+@MainActor
+final class DisabledLogR: LogRService {
+    var recentLogs: Deque<LogEntry> { Deque() }
+
+    var canAnalyseLogs: Bool { false }
+
+    @available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 12.0, *)
+    var privacyAnalysisResult: PrivacyAnalysisResult? { nil }
+
+    @available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 12.0, *)
+    var logIssueSummary: LogIssueSummary? { nil }
+
+    @available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 12.0, *)
+    var analysisProgress: AnalysisProgress? { nil }
+
+    init() {}
+
+    func log(level: LogLevel,
+             message: @autoclosure () -> String,
+             category: LogCategory,
+             file: String,
+             function: String,
+             line: Int,
+             metadata: [String: LogMetadataValue]?) {}
+
+    func clearLogs() async throws {}
+
+    func flush() async {}
+
+    @available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 12.0, *)
+    func scanForPrivacyIssues() async throws -> PrivacyAnalysisResult {
+        throw AIAnalyzerError.missingAnalyzer
+    }
+
+    @available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 12.0, *)
+    func summarizeIssues() async throws -> LogIssueSummary {
+        throw AIAnalyzerError.missingAnalyzer
+    }
+}

--- a/Sources/LogrUI/Tools+Extensions/DisabledLogR.swift
+++ b/Sources/LogrUI/Tools+Extensions/DisabledLogR.swift
@@ -29,6 +29,8 @@ final class DisabledLogR: LogRService {
 
     var canAnalyseLogs: Bool { false }
 
+    var droppedLogCount: Int { 0 }
+
     @available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 12.0, *)
     var privacyAnalysisResult: PrivacyAnalysisResult? { nil }
 

--- a/Sources/LogrUI/Tools+Extensions/Presentation.swift
+++ b/Sources/LogrUI/Tools+Extensions/Presentation.swift
@@ -1,0 +1,54 @@
+//
+//  Presentation.swift
+//  Logr
+//
+//  The single source of truth for how domain values are *styled* across Logr UI.
+//
+
+import Logr
+import SwiftUI
+
+// MARK: - LogLevel presentation
+
+public extension LogLevel {
+    /// The accent color for this level — the one place level colors are defined.
+    ///
+    /// Severity *ordering* stays in the domain (``LogLevel/priority``); only the visual style lives
+    /// here. Every view resolves a level's color through this property rather than defining its own
+    /// `switch`, so the same level can never render as a different color on different screens.
+    var tint: Color {
+        switch self {
+        case .debug: .gray
+        case .info: .blue
+        case .notice: .cyan
+        case .warning: .orange
+        case .error: .red
+        case .fault: .purple
+        }
+    }
+}
+
+// MARK: - LogSeverity presentation (AI analysis, iOS 26+)
+
+@available(iOS 26.0, macOS 26.0, tvOS 26.0, watchOS 12.0, *)
+public extension LogSeverity {
+    /// The accent color for this severity — the one place severity colors are defined.
+    var tint: Color {
+        switch self {
+        case .critical: .red
+        case .high: .orange
+        case .medium: .yellow
+        case .low: .blue
+        }
+    }
+
+    /// The SF Symbol representing this severity — the one place severity symbols are defined.
+    var symbolName: String {
+        switch self {
+        case .critical: "exclamationmark.triangle.fill"
+        case .high: "exclamationmark.circle.fill"
+        case .medium: "exclamationmark.circle"
+        case .low: "info.circle"
+        }
+    }
+}

--- a/Sources/LogrUI/Tools+Extensions/SwiftUIEnvironment.swift
+++ b/Sources/LogrUI/Tools+Extensions/SwiftUIEnvironment.swift
@@ -11,15 +11,16 @@ import SwiftUI
 // MARK: - Environment Key and Values
 
 public extension EnvironmentValues {
-    #if DEBUG
-    @Entry var logService: LogRService = MockLogR()
-    #else
-    @Entry var logService: LogRService = LogR()
-    #endif
+    /// The logging service available to `LogrUI` views.
+    ///
+    /// Defaults to a no-op ``DisabledLogR`` so views render a safe, empty state
+    /// when no logger has been injected. Provide a real service with
+    /// ``SwiftUICore/View/logRService(_:)`` (or `.environment(\.logService, logger)`).
+    @Entry var logService: any LogRService = DisabledLogR()
 }
 
 public struct LogRServiceModifier: ViewModifier {
-    let service: LogRService
+    let service: any LogRService
 
     public func body(content: Content) -> some View {
         content
@@ -28,8 +29,8 @@ public struct LogRServiceModifier: ViewModifier {
 }
 
 public extension View {
-    /// Injects a LogRService into the SwiftUI environment
-    func logRService(_ service: LogRService) -> some View {
+    /// Injects a `LogRService` into the SwiftUI environment.
+    func logRService(_ service: any LogRService) -> some View {
         modifier(LogRServiceModifier(service: service))
     }
 }

--- a/Tests/LogrTests/AnalyzerConfigurationTests.swift
+++ b/Tests/LogrTests/AnalyzerConfigurationTests.swift
@@ -1,0 +1,19 @@
+import Testing
+@testable import Logr
+
+@Suite("Analyzer Configuration")
+struct AnalyzerConfigurationTests {
+    @Test("Default concurrency matches the documented 2-3 recommendation")
+    func testDefaultConcurrency() {
+        #expect(AnalyzerConfiguration().maxConcurrentChunks == 3)
+    }
+
+    @Test("maxConcurrentChunks is clamped to a safe range")
+    func testConcurrencyClamping() {
+        // On-device models are resource constrained; a pathological value is capped.
+        #expect(AnalyzerConfiguration(maxConcurrentChunks: 1000).maxConcurrentChunks == 8)
+        // And the lower bound stays at least 1.
+        #expect(AnalyzerConfiguration(maxConcurrentChunks: 0).maxConcurrentChunks == 1)
+        #expect(AnalyzerConfiguration(maxConcurrentChunks: -5).maxConcurrentChunks == 1)
+    }
+}

--- a/Tests/LogrTests/ConcurrentLoggingTests.swift
+++ b/Tests/LogrTests/ConcurrentLoggingTests.swift
@@ -39,6 +39,8 @@ struct ConcurrentLoggingTests {
             await group.waitForAll()
         }
 
+        await logr.flush()
+
         // Verify all logs were captured
         let expectedTotal = logCount * threadCount
         #expect(logr.recentLogs.count == expectedTotal)

--- a/Tests/LogrTests/FileSystemStorageTests.swift
+++ b/Tests/LogrTests/FileSystemStorageTests.swift
@@ -757,4 +757,55 @@ struct FileSystemStorageTests {
         let entries = try await storage.fetchEntries()
         #expect(entries.count == 100)
     }
+
+    // MARK: - NDJSON Robustness
+
+    @Test("A torn final NDJSON line is skipped while earlier entries survive")
+    func testTornFinalLineIsSkipped() async throws {
+        let uniqueFileName = "test_torn_\(UUID().uuidString).json"
+        guard let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+        else {
+            Issue.record("Documents directory not found")
+            return
+        }
+        let fileURL = documentsPath.appendingPathComponent(uniqueFileName)
+
+        let storage = try FileSystemStorage(fileName: uniqueFileName)
+        for index in 1 ... 3 {
+            try await storage.store(EncryptedLogEntry(id: "e\(index)",
+                                                      timestamp: Date().addingTimeInterval(TimeInterval(index)),
+                                                      data: Data("d\(index)".utf8)))
+        }
+
+        // Simulate a crash mid-append: a partial, undecodable trailing line with no newline.
+        let handle = try FileHandle(forWritingTo: fileURL)
+        try handle.seekToEnd()
+        try handle.write(contentsOf: Data(#"{"id":"partial","timestamp":"#.utf8))
+        try handle.close()
+
+        // A fresh instance reads the intact entries and skips the torn line instead of losing all.
+        let reopened = try FileSystemStorage(fileName: uniqueFileName)
+        let entries = try await reopened.fetchEntries()
+        #expect(entries.map(\.id) == ["e1", "e2", "e3"])
+        #expect(try await reopened.count() == 3)
+
+        cleanupTestStorage(fileName: uniqueFileName)
+    }
+
+    @Test("count() matches the decoded entry count even for newline-bearing payloads")
+    func testCountMatchesDecodedCountWithNewlinePayloads() async throws {
+        let storage = try createTestStorage()
+        for index in 1 ... 6 {
+            // The payload contains raw newlines; they must not inflate the newline-based count(),
+            // because `EncryptedLogEntry.data` is base64-encoded in the stored JSON.
+            try await storage.store(EncryptedLogEntry(id: "e\(index)",
+                                                      timestamp: Date(),
+                                                      data: Data("multi\nline\npayload \(index)".utf8)))
+        }
+
+        let counted = try await storage.count()
+        let fetched = try await storage.fetchEntries().count
+        #expect(counted == 6)
+        #expect(counted == fetched)
+    }
 }

--- a/Tests/LogrTests/FileSystemStorageTests.swift
+++ b/Tests/LogrTests/FileSystemStorageTests.swift
@@ -70,6 +70,41 @@ struct FileSystemStorageTests {
         cleanupTestStorage(fileName: uniqueFileName)
     }
 
+    @Test("Test reading and appending to a legacy JSON-array file")
+    func testReadsLegacyJSONArrayFile() async throws {
+        let uniqueFileName = "test_legacy_\(UUID().uuidString).json"
+        guard let documentsPath = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+        else {
+            Issue.record("Documents directory not found")
+            return
+        }
+        let fileURL = documentsPath.appendingPathComponent(uniqueFileName)
+
+        // Write a legacy file: a single JSON array of entries (the pre-NDJSON format).
+        let legacyEntries = (1 ... 3).map { index in
+            EncryptedLogEntry(id: "legacy-\(index)",
+                              timestamp: Date().addingTimeInterval(TimeInterval(index)),
+                              data: Data("d\(index)".utf8))
+        }
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        try encoder.encode(legacyEntries).write(to: fileURL, options: .atomic)
+
+        // Opening with FileSystemStorage should read the legacy entries…
+        let storage = try FileSystemStorage(fileName: uniqueFileName)
+        #expect(try await storage.count() == 3)
+
+        // …and appending a new entry should still work, preserving the legacy ones.
+        try await storage.store(EncryptedLogEntry(id: "new",
+                                                  timestamp: Date().addingTimeInterval(100),
+                                                  data: Data("new".utf8)))
+        let entries = try await storage.fetchEntries()
+        #expect(entries.count == 4)
+        #expect(Set(entries.map(\.id)) == Set(["legacy-1", "legacy-2", "legacy-3", "new"]))
+
+        cleanupTestStorage(fileName: uniqueFileName)
+    }
+
     // MARK: - Store Tests
 
     @Test("Test store single entry")
@@ -138,8 +173,8 @@ struct FileSystemStorageTests {
         #expect(count == 1)
     }
 
-    @Test("Test entries are sorted by timestamp after store")
-    func testEntriesAreSortedByTimestampAfterStore() async throws {
+    @Test("Test entries are returned in chronological (oldest-first) order after store")
+    func testEntriesAreReturnedInChronologicalOrderAfterStore() async throws {
         let storage = try createTestStorage()
 
         let now = Date()
@@ -154,15 +189,16 @@ struct FileSystemStorageTests {
             data: Data("new".utf8)
         )
 
-        try await storage.store(entry1)
-        try await storage.store(entry2)
+        try await storage.store(entry1) // older
+        try await storage.store(entry2) // newer
 
         let entries = try await storage.fetchEntries()
 
         #expect(entries.count == 2)
-        // Should be sorted newest first (descending)
-        #expect(entries[0].id == "entry-2")
-        #expect(entries[1].id == "entry-1")
+        // Append-only storage preserves insertion order, which is chronological
+        // (oldest first) — matching the LogRPersistence contract and SQLiteStorage.
+        #expect(entries[0].id == "entry-1")
+        #expect(entries[1].id == "entry-2")
     }
 
     // MARK: - Fetch Tests
@@ -187,6 +223,23 @@ struct FileSystemStorageTests {
         let fetchedEntries = try await storage.fetchEntries()
 
         #expect(fetchedEntries.count == 5)
+    }
+
+    @Test("fetchEntries(limit:) returns the latest entries, oldest-first")
+    func testFetchEntriesWithLimit() async throws {
+        let storage = try createTestStorage()
+        let now = Date()
+        for index in 1 ... 10 {
+            try await storage.store(EncryptedLogEntry(id: "e\(index)",
+                                                      timestamp: now.addingTimeInterval(TimeInterval(index)),
+                                                      data: Data("d\(index)".utf8)))
+        }
+
+        let latest = try await storage.fetchEntries(limit: 3)
+        #expect(latest.map(\.id) == ["e8", "e9", "e10"])
+
+        let all = try await storage.fetchEntries(limit: nil)
+        #expect(all.count == 10)
     }
 
     @Test("Test fetch entries from empty storage")
@@ -302,11 +355,11 @@ struct FileSystemStorageTests {
         let count = try await storage.count()
         #expect(count == 5)
 
-        // Verify we kept the most recent ones
+        // Verify we kept the most recent ones (entries 6-10), in chronological order.
         let entries = try await storage.fetchEntries()
         #expect(entries.count == 5)
-        // Should have entries 6-10 (newest)
-        #expect(entries[0].id == "entry-10")
+        #expect(Set(entries.map(\.id)) == Set((6 ... 10).map { "entry-\($0)" }))
+        #expect(entries.last?.id == "entry-10")
     }
 
     @Test("Test delete entries keeping latest with exact count")

--- a/Tests/LogrTests/LogrTests.swift
+++ b/Tests/LogrTests/LogrTests.swift
@@ -106,6 +106,9 @@ struct LogrTests {
         logr.error("Error")
         logr.fault("Fault")
 
+        // Publish the coalesced buffer before inspecting `recentLogs` directly.
+        await logr.flush()
+
         #expect(logr.recentLogs.count == 5)
 
         // Verify logs are in reverse chronological order (newest first)
@@ -114,6 +117,32 @@ struct LogrTests {
         #expect(logr.recentLogs[2].message == "Notice")
         #expect(logr.recentLogs[3].message == "Info")
         #expect(logr.recentLogs[4].message == "Debug")
+    }
+
+    // MARK: - Existential read consistency (A1 regression)
+
+    @Test("Reads through the LogRService existential reflect a burst with no await")
+    func testExistentialReadsReflectBurstImmediately() async throws {
+        // LogrUI and consumers hold the service as `any LogRService`. A burst of logs
+        // within the coalescing window must be visible to every read API immediately —
+        // the synchronous reads without any intervening `await`, through the existential,
+        // not just the concrete type.
+        let service: any LogRService = LogR(cryptoService: cryptoService)
+
+        service.info("a")
+        service.info("b")
+        service.info("c")
+
+        // Synchronous reads see the burst with no await — the core source-of-truth guarantee.
+        #expect(service.recentLogs.count == 3)
+        #expect(try service.getLogs().count == 3)
+        #expect(try service.getLogs(limit: 2).count == 2)
+
+        // Export/statistics now run off the main actor (so they're `async`), but still reflect the
+        // burst — the async is about *where* the work runs, not whether the data is current.
+        let exported = try await service.exportLogs()
+        #expect(!exported.isEmpty)
+        #expect(await service.logStatistics().totalCount == 3)
     }
 
     // MARK: - Lazy Evaluation Tests
@@ -222,6 +251,44 @@ struct LogrTests {
     }
 
     // MARK: - Configuration Tests
+
+    @Test("LogrConfiguration decodes JSON missing the 1.2.0 fields by falling back to defaults")
+    func testConfigDecodesJSONWithoutNewFields() throws {
+        // Round-trip the default config, then strip the fields added in 1.2.0 to simulate a config
+        // encoded by an earlier release. Decoding must succeed (defaults applied), not throw.
+        let encoded = try JSONEncoder().encode(LogrConfiguration.default)
+        var object = try #require(try JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+        object.removeValue(forKey: "coalesceWindowMillis")
+        object.removeValue(forKey: "mirrorToOSLog")
+        let legacy = try JSONSerialization.data(withJSONObject: object)
+
+        let config = try JSONDecoder().decode(LogrConfiguration.self, from: legacy)
+
+        #expect(config.coalesceWindowMillis == LogrConfiguration.default.coalesceWindowMillis)
+        #expect(config.mirrorToOSLog == LogrConfiguration.default.mirrorToOSLog)
+        #expect(config.maxLogEntries == LogrConfiguration.default.maxLogEntries)
+        #expect(config.subsystem == LogrConfiguration.default.subsystem)
+    }
+
+    @Test("LogrConfiguration round-trips through Codable")
+    func testConfigCodableRoundTrip() throws {
+        let original = LogrConfiguration(maxLogEntries: 42,
+                                         enabledLevels: [.warning, .error],
+                                         subsystem: "com.test.roundtrip",
+                                         logVerbosity: .normal,
+                                         coalesceWindowMillis: 250,
+                                         mirrorToOSLog: false)
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(LogrConfiguration.self, from: data)
+
+        #expect(decoded.maxLogEntries == 42)
+        #expect(decoded.enabledLevels == [.warning, .error])
+        #expect(decoded.subsystem == "com.test.roundtrip")
+        #expect(decoded.logVerbosity == .normal)
+        #expect(decoded.coalesceWindowMillis == 250)
+        #expect(decoded.mirrorToOSLog == false)
+    }
+
     @Test("Test custom configuration max log entries")
     func testMaxLogEntriesConfiguration() async throws {
         let config = LogrConfiguration(maxLogEntries: 3)
@@ -231,6 +298,8 @@ struct LogrTests {
         logr.info("Message 2")
         logr.info("Message 3")
         logr.info("Message 4")
+
+        await logr.flush()
 
         // Should only keep the 3 most recent logs
         #expect(logr.recentLogs.count == 3)
@@ -250,6 +319,8 @@ struct LogrTests {
         logr.notice("Notice message")
         logr.error("Error message")
         logr.fault("Fault message")
+
+        await logr.flush()
 
         // Should only have error and fault logs
         #expect(logr.recentLogs.count == 2)
@@ -404,13 +475,13 @@ struct LogrTests {
     // MARK: - Export Tests
 
     @Test("Test export logs as JSON")
-    func testExportLogsAsJSON() throws {
+    func testExportLogsAsJSON() async throws {
         let logr = LogR(cryptoService: cryptoService)
 
         logr.info("Test message 1", category: .system)
         logr.error("Test message 2", category: .network)
 
-        let jsonData = try #require(logr.exportLogs(format: .json))
+        let jsonData = try await logr.exportLogs(format: .json)
 
         #expect(!jsonData.isEmpty)
 
@@ -423,13 +494,13 @@ struct LogrTests {
     }
 
     @Test("Test export logs as CSV")
-    func testExportLogsAsCSV() throws {
+    func testExportLogsAsCSV() async throws {
         let logr = LogR(cryptoService: cryptoService)
 
         logr.info("Test message 1", category: .system)
         logr.error("Test message 2", category: .network)
 
-        let csvData = try #require(logr.exportLogs(format: .csv))
+        let csvData = try await logr.exportLogs(format: .csv)
 
         #expect(!csvData.isEmpty)
 
@@ -448,7 +519,7 @@ struct LogrTests {
         logr.info("Test message 1", category: .system)
         logr.error("Test message 2", category: .network)
 
-        let txtData = try #require(logr.exportLogs(format: .txt))
+        let txtData = try await logr.exportLogs(format: .txt)
 
         #expect(!txtData.isEmpty)
 
@@ -461,13 +532,13 @@ struct LogrTests {
     }
 
     @Test("Test export with special characters in CSV")
-    func testExportWithSpecialCharactersInCSV() throws {
+    func testExportWithSpecialCharactersInCSV() async throws {
         let logr = LogR(cryptoService: cryptoService)
 
         logr.info("Message with \"quotes\"", category: .system)
         logr.info("Message with, commas", category: .system)
 
-        let csvData =  try #require(logr.exportLogs(format: .csv))
+        let csvData = try await logr.exportLogs(format: .csv)
         let csvString = String(data: csvData, encoding: .utf8)
 
         #expect(csvString != nil)
@@ -484,6 +555,8 @@ struct LogrTests {
         logr.info("Message 1")
         logr.info("Message 2")
         logr.info("Message 3")
+
+        await logr.flush()
 
         #expect(logr.recentLogs.count == 3)
 
@@ -503,6 +576,8 @@ struct LogrTests {
         logr.info("Database message", category: .database)
         logr.info("UI message", category: .ui)
         logr.info("Custom message", category: .custom("MyCategory"))
+
+        await logr.flush()
 
         #expect(logr.recentLogs.count == 5)
 
@@ -525,13 +600,15 @@ struct LogrTests {
         #expect(logs.isEmpty)
     }
 
-    @Test("Test export on empty logs")
-    func testExportOnEmptyLogs() throws {
+    @Test("Test export on empty logs returns empty data (not nil)")
+    func testExportOnEmptyLogs() async throws {
         let logr = LogR(cryptoService: cryptoService)
 
-        let jsonData = logr.exportLogs(format: .json)
+        // Empty cache now yields empty `Data` rather than `nil`, so callers can distinguish
+        // "no logs" from a genuine encoding failure (which throws).
+        let jsonData = try await logr.exportLogs(format: .json)
 
-        #expect(jsonData == nil)
+        #expect(jsonData.isEmpty)
     }
 
     // MARK: - Metadata Tests
@@ -591,6 +668,8 @@ struct LogrTests {
         for i in 1...100 {
             logr.info("Message \(i)")
         }
+
+        await logr.flush()
 
         #expect(logr.recentLogs.count == 100)
     }

--- a/Tests/LogrTests/LogrTests.swift
+++ b/Tests/LogrTests/LogrTests.swift
@@ -1,6 +1,7 @@
 import Testing
 @testable import Logr
 import Foundation
+import Collections
 
 final class MockKeychainService: @unchecked Sendable, KeychainStore {
     var storage: [String: Data] = [:]
@@ -18,6 +19,17 @@ final class MockKeychainService: @unchecked Sendable, KeychainStore {
     
     func remove(forKey key: String) throws {
         storage.removeValue(forKey: key)
+    }
+}
+
+/// Counts how many times its message factory is evaluated. Used to prove that
+/// the logging `@autoclosure` is only invoked when the level is actually enabled.
+@MainActor
+final class EvaluationCounter {
+    private(set) var count = 0
+    func track() -> String {
+        count += 1
+        return "tracked-message"
     }
 }
 
@@ -102,6 +114,111 @@ struct LogrTests {
         #expect(logr.recentLogs[2].message == "Notice")
         #expect(logr.recentLogs[3].message == "Info")
         #expect(logr.recentLogs[4].message == "Debug")
+    }
+
+    // MARK: - Lazy Evaluation Tests
+
+    @Test("Disabled log level does not evaluate the message autoclosure")
+    func testDisabledLevelSkipsMessageEvaluation() async throws {
+        let config = LogrConfiguration(enabledLevels: [.error, .fault])
+        let logr = LogR(cryptoService: cryptoService, configuration: config)
+        let counter = EvaluationCounter()
+
+        // `.debug` is not enabled — the message must never be built.
+        logr.debug(counter.track())
+        #expect(counter.count == 0)
+
+        // `.error` is enabled — the message is built exactly once.
+        logr.error(counter.track())
+        #expect(counter.count == 1)
+    }
+
+    @Test("Category-level override below threshold skips message evaluation")
+    func testCategoryOverrideSkipsMessageEvaluation() async throws {
+        let config = LogrConfiguration(enabledLevels: Set(LogLevel.allCases),
+                                       categoryLevelOverrides: [.network: .error])
+        let logr = LogR(cryptoService: cryptoService, configuration: config)
+        let counter = EvaluationCounter()
+
+        // `.network` only logs `.error`+ — a `.debug` to `.network` must not evaluate.
+        logr.debug(counter.track(), category: .network)
+        #expect(counter.count == 0)
+    }
+
+    // MARK: - Cleanup Tests
+
+    private func agedEntry(_ message: String, ageSeconds: TimeInterval, now: Date) -> LogEntry {
+        LogEntry(timestamp: now.addingTimeInterval(-ageSeconds),
+                 level: .info,
+                 category: .system,
+                 subsystem: "test",
+                 message: message)
+    }
+
+    @Test("Expired entries are trimmed from the tail and fresh entries kept, in order")
+    func testTrimExpiredEntries() async throws {
+        let now = Date()
+        let cutoff = now.addingTimeInterval(-60) // entries older than 60s expire
+        // Newest-first ordering: fresh at the front, oldest at the back.
+        var deque: Deque<LogEntry> = [
+            agedEntry("fresh-2", ageSeconds: 5, now: now),
+            agedEntry("fresh-1", ageSeconds: 30, now: now),
+            agedEntry("old-1", ageSeconds: 120, now: now),
+            agedEntry("old-2", ageSeconds: 600, now: now)
+        ]
+
+        LogR.trimExpiredEntries(&deque, olderThan: cutoff)
+
+        #expect(deque.map(\.message) == ["fresh-2", "fresh-1"])
+    }
+
+    @Test("Trimming is a no-op when nothing has expired")
+    func testTrimExpiredNoOp() async throws {
+        let now = Date()
+        let cutoff = now.addingTimeInterval(-3600)
+        var deque: Deque<LogEntry> = [
+            agedEntry("a", ageSeconds: 1, now: now),
+            agedEntry("b", ageSeconds: 100, now: now)
+        ]
+
+        LogR.trimExpiredEntries(&deque, olderThan: cutoff)
+
+        #expect(deque.count == 2)
+        #expect(deque.map(\.message) == ["a", "b"])
+    }
+
+    // MARK: - Load Merge Tests
+
+    @Test("Loaded history is merged newest-first, after any logs captured during launch")
+    func testMergeLoadedHistoryOrder() async throws {
+        let now = Date()
+        // As returned by fetchEntries(limit:): oldest-first.
+        let historical = [
+            agedEntry("h1", ageSeconds: 50, now: now),
+            agedEntry("h2", ageSeconds: 40, now: now),
+            agedEntry("h3", ageSeconds: 30, now: now)
+        ]
+        // Live logs captured during launch: newest-first, newer than the history.
+        var current: Deque<LogEntry> = [
+            agedEntry("live2", ageSeconds: 1, now: now),
+            agedEntry("live1", ageSeconds: 2, now: now)
+        ]
+
+        LogR.mergeLoaded(historical, into: &current, cap: 100)
+
+        #expect(current.map(\.message) == ["live2", "live1", "h3", "h2", "h1"])
+    }
+
+    @Test("Merging loaded history drops the oldest beyond the cap")
+    func testMergeLoadedRespectsCap() async throws {
+        let now = Date()
+        // oldest-first: h1 (oldest) … h6 (newest)
+        let historical = (1 ... 6).map { agedEntry("h\($0)", ageSeconds: Double(60 - $0), now: now) }
+        var current: Deque<LogEntry> = []
+
+        LogR.mergeLoaded(historical, into: &current, cap: 3)
+
+        #expect(current.map(\.message) == ["h6", "h5", "h4"])
     }
 
     // MARK: - Configuration Tests

--- a/Tests/LogrTests/ModelsTests.swift
+++ b/Tests/LogrTests/ModelsTests.swift
@@ -91,14 +91,14 @@ struct ModelsTests {
             }
         }
 
-        @Test("Test log level visual queue")
-        func testLogLevelVisualQueue() {
-            #expect(LogLevel.debug.visualQueue == "🟣")
-            #expect(LogLevel.info.visualQueue == "🔵")
-            #expect(LogLevel.notice.visualQueue == "🔵")
-            #expect(LogLevel.warning.visualQueue == "🟡")
-            #expect(LogLevel.error.visualQueue == "🔴")
-            #expect(LogLevel.fault.visualQueue == "🔴")
+        @Test("Test log level visual cue")
+        func testLogLevelVisualCue() {
+            #expect(LogLevel.debug.visualCue == "🟣")
+            #expect(LogLevel.info.visualCue == "🔵")
+            #expect(LogLevel.notice.visualCue == "🔵")
+            #expect(LogLevel.warning.visualCue == "🟡")
+            #expect(LogLevel.error.visualCue == "🔴")
+            #expect(LogLevel.fault.visualCue == "🔴")
         }
 
         @Test("Test log level CaseIterable")

--- a/Tests/LogrTests/ReviewRegressionTests.swift
+++ b/Tests/LogrTests/ReviewRegressionTests.swift
@@ -1,0 +1,123 @@
+import Collections
+import Foundation
+import Testing
+@testable import Logr
+
+// MARK: - Shared test storage
+
+/// In-memory storage implementing **only** the pre-MR `LogRPersistence` primitives — no
+/// `store(_ entries:)` and no `fetchEntries(limit:)`. Its mere existence proves the new batch
+/// requirement ships a working default (C2); it also doubles as functional storage for the
+/// clear-resurrection test (C3).
+actor PreMRInMemoryStore: LogRPersistence {
+    private(set) var entries: [EncryptedLogEntry] = []
+
+    func store(_ entry: EncryptedLogEntry) async throws { entries.append(entry) }
+    func fetchEntries() async throws -> [EncryptedLogEntry] { entries }
+    func deleteEntries(olderThan date: Date) async throws { entries.removeAll { $0.timestamp <= date } }
+    func deleteEntries(keepingLatest count: Int) async throws { entries = Array(entries.suffix(count)) }
+    func clear() async throws { entries.removeAll() }
+    func count() async throws -> Int { entries.count }
+}
+
+// MARK: - C1: crypto envelope backward/forward compatibility
+
+@Suite("Crypto envelope back-compat (C1)")
+struct CryptoEnvelopeBackCompatTests {
+    @Test("Legacy envelope without an `algorithm` field decrypts as ChaCha20-Poly1305")
+    func testLegacyEnvelopeDecodesAsChaCha() throws {
+        let crypto = try LoggerCryptoService(store: MockKeychainService(), encryptionAlgo: .chacha)
+
+        let original = LogEntry(level: .error, category: .network, subsystem: "t", message: "secret")
+        let modern = try crypto.symmetricEncrypt(object: original)
+
+        // Reproduce an envelope written by a version that predates the `algorithm` field.
+        var json = try #require(try JSONSerialization.jsonObject(with: modern) as? [String: Any])
+        #expect(json["algorithm"] != nil) // sanity: current encoder writes it
+        json.removeValue(forKey: "algorithm")
+        let legacy = try JSONSerialization.data(withJSONObject: json)
+
+        let decrypted: LogEntry = try crypto.symmetricDecrypt(encryptedData: legacy)
+        #expect(decrypted == original)
+    }
+
+    @Test("Both AES-256-GCM and ChaCha20-Poly1305 round-trip")
+    func testAlgorithmsRoundTrip() throws {
+        for algo in [LoggerCryptoService.CryptoAlgo.aes256gcm, .chacha] {
+            let crypto = try LoggerCryptoService(store: MockKeychainService(), encryptionAlgo: algo)
+            let original = LogEntry(level: .info, category: .system, subsystem: "t", message: "hello")
+            let data = try crypto.symmetricEncrypt(object: original)
+            let decrypted: LogEntry = try crypto.symmetricDecrypt(encryptedData: data)
+            #expect(decrypted == original)
+        }
+    }
+}
+
+// MARK: - C2 / C3 / R-Flush
+
+@MainActor
+@Suite("Review regressions (C2, C3, R-Flush)")
+struct ReviewRegressionTests {
+    private func makeCrypto() throws -> LoggerCryptoService {
+        try LoggerCryptoService(store: MockKeychainService())
+    }
+
+    @Test("A custom backend implementing only pre-MR methods batches via the default (C2)")
+    func testBatchStoreDefaultForCustomBackend() async throws {
+        let store = PreMRInMemoryStore()
+        let entries = (0 ..< 3).map {
+            EncryptedLogEntry(id: "\($0)", timestamp: Date(), data: Data([UInt8($0)]))
+        }
+        // Resolves to the `LogRPersistence` extension default — the type compiles without its own
+        // `store(_ entries:)`, which is the compatibility guarantee.
+        try await store.store(entries)
+        #expect(try await store.count() == 3)
+    }
+
+    @Test("clearLogs() clears storage even with writes still buffered — no resurrection (C3)")
+    func testClearLogsLeavesNoResurrectedEntries() async throws {
+        let storage = PreMRInMemoryStore()
+        let logr = LogR(storage: storage, cryptoService: try makeCrypto())
+
+        for index in 0 ..< 200 { logr.info("msg \(index)") }
+        // Clear WITHOUT flushing first: entries may still be queued in the writer.
+        try await logr.clearLogs()
+        await logr.flush() // drain anything the writer still held after the clear
+
+        #expect(logr.recentLogs.isEmpty)
+        #expect(try await storage.count() == 0)
+    }
+
+    @Test("flush() returns promptly after the writer's stream has finished (R-Flush)")
+    func testFlushAfterShutdownDoesNotHang() async throws {
+        let writer = LogWriterActor(storage: PreMRInMemoryStore(),
+                                    cryptoService: try makeCrypto(),
+                                    configuration: .default)
+        writer.ingest(LogEntry(level: .info, category: .system, subsystem: "t", message: "m"))
+        writer.shutdown() // finishes the stream
+
+        // Race flush() against a timeout. With the `.terminated` guard, flush resumes immediately;
+        // without it the continuation would be dropped and this would never return.
+        let returned = await withTaskGroup(of: Bool.self) { group in
+            group.addTask { await writer.flush(); return true }
+            group.addTask { try? await Task.sleep(for: .seconds(2)); return false }
+            let first = await group.next() ?? false
+            group.cancelAll()
+            return first
+        }
+        #expect(returned)
+    }
+
+    @Test("logStatistics() computes correct per-level counts (R-Perf)")
+    func testStatisticsComputedOffMain() async throws {
+        let logr = LogR(cryptoService: try makeCrypto())
+        logr.info("a")
+        logr.info("b")
+        logr.error("c")
+
+        let stats = await logr.logStatistics()
+        #expect(stats.totalCount == 3)
+        #expect(stats.countByLevel[.info] == 2)
+        #expect(stats.countByLevel[.error] == 1)
+    }
+}

--- a/Tests/LogrTests/SQLiteStorageTests.swift
+++ b/Tests/LogrTests/SQLiteStorageTests.swift
@@ -15,6 +15,23 @@ struct SQLiteStorageTests {
         return try SQLiteStorage(databasePath: testDBPath)
     }
 
+    @Test("fetchEntries(limit:) returns the latest entries, oldest-first")
+    func testFetchEntriesWithLimit() async throws {
+        let storage = try createTestDatabase()
+        let now = Date()
+        for index in 1 ... 10 {
+            try await storage.store(EncryptedLogEntry(id: "e\(index)",
+                                                      timestamp: now.addingTimeInterval(TimeInterval(index)),
+                                                      data: Data("d\(index)".utf8)))
+        }
+
+        let latest = try await storage.fetchEntries(limit: 3)
+        #expect(latest.map(\.id) == ["e8", "e9", "e10"])
+
+        let all = try await storage.fetchEntries(limit: nil)
+        #expect(all.count == 10)
+    }
+
     // MARK: - Initialization Tests
 
     @Test("Test database initialization with custom path")

--- a/Tests/LogrTests/WriterReliabilityTests.swift
+++ b/Tests/LogrTests/WriterReliabilityTests.swift
@@ -44,6 +44,30 @@ actor FlakyStorage: LogRPersistence {
     func count() async throws -> Int { entries.count }
 }
 
+/// In-memory storage that delays every write, so entries pile up in the writer's pending buffer
+/// faster than they drain. Used to exercise backpressure.
+actor SlowStorage: LogRPersistence {
+    private let delay: Duration
+    private(set) var entries: [EncryptedLogEntry] = []
+
+    init(delay: Duration) { self.delay = delay }
+
+    var storedCount: Int { entries.count }
+
+    func store(_ entry: EncryptedLogEntry) async throws { try await store([entry]) }
+
+    func store(_ newEntries: [EncryptedLogEntry]) async throws {
+        try? await Task.sleep(for: delay)
+        entries.append(contentsOf: newEntries)
+    }
+
+    func fetchEntries() async throws -> [EncryptedLogEntry] { entries }
+    func deleteEntries(olderThan date: Date) async throws {}
+    func deleteEntries(keepingLatest count: Int) async throws {}
+    func clear() async throws { entries.removeAll() }
+    func count() async throws -> Int { entries.count }
+}
+
 @MainActor
 @Suite("Writer Reliability")
 struct WriterReliabilityTests {
@@ -78,5 +102,48 @@ struct WriterReliabilityTests {
 
         let stored = await storage.storedCount
         #expect(stored == 120)
+    }
+
+    @Test("droppedLogCount surfaces persistence loss through the LogRService existential")
+    func testDroppedLogCountVisibleViaExistential() async throws {
+        // Fails enough times to exhaust the writer's retries, so the batch is dropped and reported.
+        let storage = FlakyStorage(failingFirst: 3)
+        let service: any LogRService = LogR(storage: storage, cryptoService: try makeCrypto())
+
+        service.info("x")
+        await service.flush()
+
+        // onDrop hops to the main actor via a Task, so allow the pending update to apply.
+        for _ in 0 ..< 50 where service.droppedLogCount == 0 {
+            try? await Task.sleep(for: .milliseconds(10))
+        }
+        #expect(service.droppedLogCount == 1)
+    }
+
+    @Test("Backpressure bounds the pending buffer and accounts every shed entry")
+    func testBackpressureBoundsBufferAndAccountsDrops() async throws {
+        // Storage can't keep up: with a tiny pending cap, a fast burst must shed the excess.
+        let storage = SlowStorage(delay: .milliseconds(50))
+        let droppedBox = SafeMutex.create(0)
+        let writer = LogWriterActor(storage: storage,
+                                    cryptoService: try makeCrypto(),
+                                    configuration: .default,
+                                    batchSize: 5,
+                                    maxRetries: 1,
+                                    maxPendingWrites: 10)
+        await writer.setOnDrop { count in droppedBox.modify { $0 += count } }
+
+        let total = 200
+        for index in 0 ..< total {
+            writer.ingest(LogEntry(level: .info, category: .system, subsystem: "t", message: "m\(index)"))
+        }
+        await writer.flush()
+
+        let stored = await storage.storedCount
+        let dropped = droppedBox.value
+        // Every entry is either persisted or accounted as a backpressure drop — none vanish silently.
+        #expect(stored + dropped == total)
+        // The buffer shed load instead of growing without bound.
+        #expect(dropped > 0)
     }
 }

--- a/Tests/LogrTests/WriterReliabilityTests.swift
+++ b/Tests/LogrTests/WriterReliabilityTests.swift
@@ -1,0 +1,82 @@
+import Testing
+@testable import Logr
+import Foundation
+
+/// In-memory storage whose batch `store` throws for the first `failingFirst` calls,
+/// then succeeds. Used to prove the background writer re-tries a failed batch instead
+/// of silently dropping it.
+actor FlakyStorage: LogRPersistence {
+    enum StorageError: Error { case transient }
+
+    private var failuresRemaining: Int
+    private(set) var entries: [EncryptedLogEntry] = []
+
+    init(failingFirst failures: Int) {
+        failuresRemaining = failures
+    }
+
+    var storedCount: Int { entries.count }
+
+    func store(_ entry: EncryptedLogEntry) async throws {
+        try await store([entry])
+    }
+
+    func store(_ newEntries: [EncryptedLogEntry]) async throws {
+        if failuresRemaining > 0 {
+            failuresRemaining -= 1
+            throw StorageError.transient
+        }
+        entries.append(contentsOf: newEntries)
+    }
+
+    func fetchEntries() async throws -> [EncryptedLogEntry] { entries }
+
+    func deleteEntries(olderThan date: Date) async throws {
+        entries.removeAll { $0.timestamp < date }
+    }
+
+    func deleteEntries(keepingLatest count: Int) async throws {
+        entries = Array(entries.suffix(count))
+    }
+
+    func clear() async throws { entries.removeAll() }
+
+    func count() async throws -> Int { entries.count }
+}
+
+@MainActor
+@Suite("Writer Reliability")
+struct WriterReliabilityTests {
+    private func makeCrypto() throws -> LoggerCryptoService {
+        try LoggerCryptoService(store: MockKeychainService())
+    }
+
+    @Test("A transient store failure does not lose log entries")
+    func testTransientFailureDoesNotDrop() async throws {
+        let storage = FlakyStorage(failingFirst: 1)
+        let logr = LogR(storage: storage, cryptoService: try makeCrypto())
+
+        logr.info("a")
+        logr.info("b")
+        logr.info("c")
+
+        await logr.flush()
+
+        let stored = await storage.storedCount
+        #expect(stored == 3)
+    }
+
+    @Test("All logged entries are persisted after flush")
+    func testFlushPersistsAll() async throws {
+        let storage = FlakyStorage(failingFirst: 0)
+        let logr = LogR(storage: storage, cryptoService: try makeCrypto())
+
+        for index in 0 ..< 120 {
+            logr.info("msg \(index)")
+        }
+        await logr.flush()
+
+        let stored = await storage.storedCount
+        #expect(stored == 120)
+    }
+}

--- a/docs/Articles/AIAnalysis.md
+++ b/docs/Articles/AIAnalysis.md
@@ -31,7 +31,7 @@ import Logr
 
 if #available(iOS 26.0, *) {
     let analyzer = AIAnalyzer()
-    let logger = LogR(
+    let logger = try LogR(
         storage: SQLiteStorage(),
         logAnalyser: analyzer
     )
@@ -355,7 +355,7 @@ class CustomAIAnalyzer: LogAIAnalyzer {
 // Use it
 if #available(iOS 26.0, *) {
     let customAnalyzer = CustomAIAnalyzer()
-    let logger = LogR(logAnalyser: customAnalyzer)
+    let logger = try LogR(logAnalyser: customAnalyzer)
 }
 ```
 

--- a/docs/Articles/Architecture.md
+++ b/docs/Articles/Architecture.md
@@ -288,7 +288,7 @@ class CloudStorage: LogRPersistence {
     // Implement other methods...
 }
 
-let logger = LogR(storage: CloudStorage())
+let logger = try LogR(storage: CloudStorage())
 ```
 
 ### Custom Crypto
@@ -327,7 +327,7 @@ class CustomAI: LogAIAnalyzer {
     }
 }
 
-let logger = LogR(logAnalyser: CustomAI())
+let logger = try LogR(logAnalyser: CustomAI())
 ```
 
 ## Design Principles

--- a/docs/Articles/GettingStarted.md
+++ b/docs/Articles/GettingStarted.md
@@ -52,7 +52,7 @@ import Logr
 
 @main
 struct MyApp: App {
-    let logger = LogR()
+    let logger = try! LogR()
 
     var body: some Scene {
         WindowGroup {
@@ -74,10 +74,10 @@ import Logr
 @main
 struct MyApp: App {
     // SQLite storage (recommended for large volumes)
-    let logger = LogR(storage: SQLiteStorage())
+    let logger = try LogR(storage: SQLiteStorage())
 
     // Or FileSystem storage (simple JSON files)
-    // let logger = LogR(storage: FileSystemStorage())
+    // let logger = try! LogR(storage: FileSystemStorage())
 
     var body: some Scene {
         WindowGroup {
@@ -220,7 +220,7 @@ import LogrUI
 
 @main
 struct MyApp: App {
-    let logger = LogR(storage: SQLiteStorage())
+    let logger = try! LogR(storage: SQLiteStorage())
 
     var body: some Scene {
         WindowGroup {
@@ -257,7 +257,7 @@ let config = LogrConfiguration(
     logVerbosity: .normal              // Normal verbosity (no source location)
 )
 
-let logger = LogR(
+let logger = try LogR(
     storage: SQLiteStorage(),
     configuration: config
 )
@@ -289,7 +289,7 @@ struct MyApp: App {
         )
         #endif
 
-        return LogR(storage: SQLiteStorage(), configuration: config)
+        return try LogR(storage: SQLiteStorage(), configuration: config)
     }()
 
     var body: some Scene {
@@ -361,7 +361,7 @@ func performRequest() async throws -> Response {
 @main
 struct MyApp: App {
     @Environment(\.scenePhase) private var scenePhase
-    let logger = LogR(storage: SQLiteStorage())
+    let logger = try! LogR(storage: SQLiteStorage())
 
     var body: some Scene {
         WindowGroup {

--- a/docs/Articles/PrivacyAndSecurity.md
+++ b/docs/Articles/PrivacyAndSecurity.md
@@ -50,11 +50,11 @@ Encryption happens automatically when using storage:
 
 ```swift
 // With SQLite
-let logger = LogR(storage: SQLiteStorage())
+let logger = try LogR(storage: SQLiteStorage())
 logger.info("Sensitive data") // Automatically encrypted before storage
 
 // With FileSystem
-let logger = LogR(storage: FileSystemStorage())
+let logger = try LogR(storage: FileSystemStorage())
 logger.info("User action") // Automatically encrypted before storage
 ```
 
@@ -82,7 +82,7 @@ Encryption keys are managed securely by the `LoggerCryptoService`.
 
 ```swift
 // Keys are generated automatically on first use
-let logger = LogR(storage: SQLiteStorage())
+let logger = try LogR(storage: SQLiteStorage())
 // On first run, a new key is generated and stored in Keychain
 ```
 
@@ -340,10 +340,10 @@ Always use storage with encryption in production:
 
 ```swift
 // ✅ Production
-let logger = LogR(storage: SQLiteStorage())
+let logger = try LogR(storage: SQLiteStorage())
 
 // ❌ Only for development
-let logger = LogR()
+let logger = try LogR()
 ```
 
 ### 2. Configure Appropriate Retention
@@ -424,7 +424,7 @@ Never extract or export encryption keys:
 let key = cryptoService.getCurrentKey() // Don't do this
 
 // ✅ Good - keys stay in crypto service
-let logger = LogR(storage: SQLiteStorage()) // Keys managed internally
+let logger = try LogR(storage: SQLiteStorage()) // Keys managed internally
 ```
 
 ### 8. Use Categories Wisely

--- a/docs/Articles/StorageAndPersistence.md
+++ b/docs/Articles/StorageAndPersistence.md
@@ -22,7 +22,7 @@ Logr provides flexible storage options for persisting logs. All stored logs are 
 Use Logr without persistent storage:
 
 ```swift
-let logger = LogR()
+let logger = try LogR()
 ```
 
 **When to use:**
@@ -40,7 +40,7 @@ let logger = LogR()
 Simple JSON-based file storage:
 
 ```swift
-let logger = LogR(storage: FileSystemStorage())
+let logger = try LogR(storage: FileSystemStorage())
 ```
 
 **Features:**
@@ -68,7 +68,7 @@ Documents/
 High-performance SQLite database:
 
 ```swift
-let logger = LogR(storage: SQLiteStorage())
+let logger = try LogR(storage: SQLiteStorage())
 ```
 
 **Features:**
@@ -102,13 +102,13 @@ CREATE INDEX idx_timestamp ON encrypted_logs(timestamp);
 import Logr
 
 // SQLite (recommended)
-let logger = LogR(storage: SQLiteStorage())
+let logger = try LogR(storage: SQLiteStorage())
 
 // FileSystem
-let logger = LogR(storage: FileSystemStorage())
+let logger = try LogR(storage: FileSystemStorage())
 
 // No storage
-let logger = LogR()
+let logger = try LogR()
 ```
 
 ### Custom Storage Location
@@ -122,7 +122,7 @@ let documentsURL = FileManager.default
 let customURL = documentsURL.appendingPathComponent("MyLogs")
 
 let storage = FileSystemStorage(directoryURL: customURL)
-let logger = LogR(storage: storage)
+let logger = try LogR(storage: storage)
 ```
 
 ### App Group Storage
@@ -134,7 +134,7 @@ let groupURL = FileManager.default
     .containerURL(forSecurityApplicationGroupIdentifier: "group.com.myapp")!
 let storage = SQLiteStorage(databaseURL: groupURL.appendingPathComponent("logs.db"))
 
-let logger = LogR(storage: storage)
+let logger = try LogR(storage: storage)
 ```
 
 ## Custom Storage Implementation
@@ -207,7 +207,7 @@ class CloudStorage: LogRPersistence {
 
 // Use it
 let cloudStorage = CloudStorage(apiClient: myAPIClient)
-let logger = LogR(storage: cloudStorage)
+let logger = try LogR(storage: cloudStorage)
 ```
 
 ### Core Data Storage Example
@@ -273,13 +273,13 @@ class CoreDataStorage: LogRPersistence {
 
 ```swift
 // For production apps with high volumes
-let logger = LogR(storage: SQLiteStorage())
+let logger = try LogR(storage: SQLiteStorage())
 
 // For simple apps or prototyping
-let logger = LogR(storage: FileSystemStorage())
+let logger = try LogR(storage: FileSystemStorage())
 
 // For development without persistence needs
-let logger = LogR()
+let logger = try LogR()
 ```
 
 ### 2. Configure Retention Appropriately
@@ -291,7 +291,7 @@ let config = LogrConfiguration(
     cleanupInterval: 60 * 60     // Regular cleanup
 )
 
-let logger = LogR(
+let logger = try LogR(
     storage: SQLiteStorage(),
     configuration: config
 )

--- a/docs/Articles/SwiftUIIntegration.md
+++ b/docs/Articles/SwiftUIIntegration.md
@@ -27,7 +27,7 @@ import Logr
 
 @main
 struct MyApp: App {
-    let logger = LogR(storage: SQLiteStorage())
+    let logger = try! LogR(storage: SQLiteStorage())
 
     var body: some Scene {
         WindowGroup {
@@ -86,7 +86,7 @@ struct LogsView: View {
 ```swift
 @main
 struct MyApp: App {
-    let logger = LogR(storage: SQLiteStorage())
+    let logger = try! LogR(storage: SQLiteStorage())
 
     var body: some Scene {
         WindowGroup {
@@ -529,7 +529,7 @@ Create one logger instance per app:
 @main
 struct MyApp: App {
     // Single instance
-    let logger = LogR(storage: SQLiteStorage())
+    let logger = try! LogR(storage: SQLiteStorage())
 
     var body: some Scene {
         WindowGroup {

--- a/docs/Articles/TestingAndMocking.md
+++ b/docs/Articles/TestingAndMocking.md
@@ -195,7 +195,7 @@ func testLoggingOnError() async throws {
 ```swift
 func testDebugLogsDisabledInProduction() {
     // Given
-    let productionLogger = LogR(
+    let productionLogger = try LogR(
         configuration: LogrConfiguration(
             enabledLevels: [.info, .warning, .error, .fault]
         )
@@ -353,7 +353,7 @@ class LogRIntegrationTests: XCTestCase {
             databaseURL: testDirectory.appendingPathComponent("test.db")
         )
 
-        logger = LogR(storage: storage)
+        logger = try LogR(storage: storage)
     }
 
     override func tearDown() {
@@ -380,7 +380,7 @@ func testLogsPersistAcrossInstances() async throws {
     let storage = SQLiteStorage(
         databaseURL: testDirectory.appendingPathComponent("test.db")
     )
-    let newLogger = LogR(storage: storage)
+    let newLogger = try LogR(storage: storage)
 
     // Wait for initialization
     try await Task.sleep(for: .seconds(1))
@@ -401,7 +401,7 @@ func testAutomaticCleanup() async throws {
         cleanupInterval: 2 // 2 seconds
     )
 
-    let logger = LogR(
+    let logger = try LogR(
         storage: SQLiteStorage(),
         configuration: config
     )
@@ -424,7 +424,7 @@ func testLogsAreEncrypted() async throws {
     let storage = SQLiteStorage(
         databaseURL: testDirectory.appendingPathComponent("test.db")
     )
-    let logger = LogR(storage: storage)
+    let logger = try LogR(storage: storage)
 
     logger.info("Secret message", category: .system)
     await logger.flush()
@@ -601,7 +601,7 @@ func testQueryPerformance() {
 // ❌ Bad - slow, file I/O in previews
 #Preview {
     ContentView()
-        .environment(\.logService, LogR(storage: SQLiteStorage()))
+        .environment(\.logService, try LogR(storage: SQLiteStorage()))
 }
 ```
 
@@ -645,7 +645,7 @@ func testOnlyLogsEnabledLevels() {
     let config = LogrConfiguration(
         enabledLevels: [.error, .fault]
     )
-    let logger = LogR(configuration: config)
+    let logger = try LogR(configuration: config)
 
     logger.debug("Debug", category: .debug)
     logger.info("Info", category: .system)
@@ -682,7 +682,7 @@ func testAsyncLogging() async throws {
 ```swift
 func testWithVerboseLogging() {
     let config = LogrConfiguration(logVerbosity: .verbose)
-    let logger = LogR(configuration: config)
+    let logger = try LogR(configuration: config)
 
     logger.info("Test message", category: .test)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ import SwiftUI
 
 @main
 struct MyApp: App {
-    @State private var logger = LogR(storage: SQLiteStorage())
+    @State private var logger = try! LogR(storage: SQLiteStorage())
 
     var body: some Scene {
         WindowGroup {


### PR DESCRIPTION
# Logr: AsyncStream logging engine, AI analysis, and hardening

## Summary
Major evolution of Logr from a basic logger into a production-grade, concurrency-safe
logging framework for Apple platforms. Reworks the write pipeline around a single
`AsyncStream` consumer, adds optional on-device AI log analysis (iOS/macOS 26+),
modularizes the SwiftUI layer, ships a full example app and DocC documentation, and
hardens crypto, storage, and the public API ahead of tagging.

## Highlights

### Core engine
- **Background writer rewrite** (`LogWriterActor`): one ordered `AsyncStream` consumer
  encrypts off the main actor, batches writes, retries transient failures with backoff,
  and bounds memory via backpressure with drop accounting. No per-log `Task`, no
  main-actor accumulation, guaranteed write ordering.
- **Coalesced observation**: `recentLogs` is updated synchronously (every reader sees a
  burst immediately) while SwiftUI invalidations are throttled to one per
  `coalesceWindowMillis`.
- **Deterministic `flush()`** for guaranteed persistence before termination / in tests.
- Newest-first cache (`Deque<LogEntry>`) enabling O(expired) tail-trimming and a
  startup load capped at `maxLogEntries`.

### AI analysis (iOS/macOS/tvOS 26+, watchOS 12+)
- `LogAIAnalyzer` + `AIAnalyzer` (FoundationModels) for privacy-exposure scanning and
  issue summarization, with progress reporting and strongly-typed `LogSeverity`.

### Storage, crypto & privacy
- `LogRPersistence` with FileSystem (append-only NDJSON) and SQLite (GRDB, limit/order
  pushdown) backends; batch `store(_:)` and `fetchEntries(limit:)`.
- Crypto hardening: pluggable algorithm (AES-256-GCM default), throwing init instead of
  `fatalError`, checked `SecRandomCopyBytes`, algorithm-tagged envelope that stays
  backward-compatible with legacy ChaCha20-Poly1305 data.
- `RedactionHelpers` for masking PII (email, card, phone, SSN, IP) and structured,
  type-safe `LogMetadataValue`.

### SwiftUI & tooling
- Modular `LogrUI` (log browser, filtering, statistics, export/share, AI views) with a
  single source of truth for level/severity styling.
- New `LogRExample` app and a full DocC documentation set.

## Review hardening (pre-merge)
Applied after a senior review of the branch:
- **Crypto back-compat**: legacy `{version,data}` envelopes decrypt as ChaCha20-
  (no data loss on upgrade).
- **`store(_ entries:)`** ships a default impl — custom backends keep compiling.
- **`clearLogs()`** is now ordered through the writer stream, so buffered writes
  longer "resurrect" in storage after a clear.
- **Single presentation source**: removed divergent per-view level/severity colo
  palettes; ordering stays in `priority`.
- **Off-main analytics**: `exportLogs`/`logStatistics` no longer block the main
  no longer recompute on every SwiftUI body pass.
- **`flush()`** can no longer leak its continuation / hang after shutdown.
- Misc: `visualQueue` → `visualCue`, `Any?` analyzer storage, `exportLogs` error
  semantics, doc examples corrected.

## ⚠️ Breaking changes
- `LogR()` / `LogR(storage:)` / `LogR(configuration:)` now **`throws`** — use `t
- `exportLogs(format:)` is now **`async throws -> Data`** (was `-> Data?`); empt
  returns empty `Data`, encoding errors throw.
- `logStatistics()` is now **`async`**.
- `recentLogs` is `Deque<LogEntry>` (requires `import Collections`).
- `LogLevel.visualQueue` renamed to **`visualCue`**.
- Crypto default algorithm is AES-256-GCM (existing encrypted logs still decrypt

## Testing
- `swift build && swift test --parallel` — **195 tests pass** across 15 suites.
- New regression coverage: legacy crypto-envelope decode + algorithm round-trips
  batch-store default for custom backends, `clearLogs()` no-resurrection, off-ma
  statistics, and `flush()`-after-shutdown.

## Platforms
iOS 17 / macOS 14 / tvOS 17 / watchOS 10 (AI features require iOS 26 / macOS 26
tvOS 26 / watchOS 12). Swift 6.2, full concurrency safety.